### PR TITLE
feat: keep the selected package manager when page referesh

### DIFF
--- a/components/core/install-command.tsx
+++ b/components/core/install-command.tsx
@@ -1,3 +1,4 @@
+
 "use client";
 
 import { CopyButton } from "@/components/core/copy-button";
@@ -26,9 +27,17 @@ export function InstallCommand({ component }: InstallCommandProps) {
   const [highlightedCode, setHighlightedCode] = React.useState<
     Record<string, string>
   >({});
+  const [selectedPM, setSelectedPM] = React.useState<string>("npm");
 
   React.useEffect(() => {
-    Promise.all(
+    const saved = localStorage.getItem("preferred-package-manager");
+    if (saved && packageManagers.some((pm) => pm.name === saved)) {
+      setSelectedPM(saved);
+    }
+  }, []);
+
+  const generateHighlightedCode = React.useCallback(async () => {
+    const results = await Promise.all(
       packageManagers.map((pm) =>
         codeToHtml(pm.command(registryUrl), {
           lang: "bash",
@@ -38,18 +47,30 @@ export function InstallCommand({ component }: InstallCommandProps) {
           },
         }).then((html) => ({ name: pm.name, html }))
       )
-    ).then((results) => {
-      const codeMap = results.reduce((acc, { name, html }) => {
-        acc[name] = html;
-        return acc;
-      }, {} as Record<string, string>);
-      setHighlightedCode(codeMap);
-    });
+    );
+    const codeMap = results.reduce((acc, { name, html }) => {
+      acc[name] = html;
+      return acc;
+    }, {} as Record<string, string>);
+    setHighlightedCode(codeMap);
   }, [registryUrl]);
+
+  React.useEffect(() => {
+    generateHighlightedCode();
+  }, [generateHighlightedCode]);
+
+  const handleTabChange = (value: string) => {
+    setSelectedPM(value);
+    localStorage.setItem("preferred-package-manager", value);
+  };
 
   return (
     <div className="relative my-6 w-full rounded-lg border">
-      <Tabs defaultValue="npm" className="w-full">
+      <Tabs
+        value={selectedPM}
+        onValueChange={handleTabChange}
+        className="w-full"
+      >
         <div className="flex items-center justify-start border-b bg-muted/50 px-4 py-2 gap-2">
           <Terminal className="w-5" />
           <TabsList className="h-auto bg-transparent p-0 ">
@@ -58,7 +79,6 @@ export function InstallCommand({ component }: InstallCommandProps) {
                 key={pm.name}
                 value={pm.name}
                 className="shadow-none! data-[state=active]:outline-1"
-                // className="rounded-none border-b-2 border-transparent bg-transparent px-3 py-1.5 text-sm font-normal shadow-none data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
               >
                 {pm.name}
               </TabsTrigger>
@@ -71,12 +91,20 @@ export function InstallCommand({ component }: InstallCommandProps) {
             value={pm.name}
             className="group relative m-0"
           >
-            <div
-              className="overflow-x-auto p-4 text-sm"
-              dangerouslySetInnerHTML={{
-                __html: highlightedCode[pm.name] || "",
-              }}
-            />
+            {highlightedCode[pm.name] ? (
+              <div
+                className="overflow-x-auto p-4 text-sm"
+                dangerouslySetInnerHTML={{
+                  __html: highlightedCode[pm.name],
+                }}
+              />
+            ) : (
+              <div className="overflow-x-auto p-4 text-sm">
+                <pre className="bg-transparent">
+                  <code>{pm.command(registryUrl)}</code>
+                </pre>
+              </div>
+            )}
             <div className="absolute right-4 top-1">
               <CopyButton value={pm.command(registryUrl)} />
             </div>


### PR DESCRIPTION
Just a small fix: keep the selected package manager after page refresh.

Changes I made:

- If I select `bun` as the package manager and then refresh the page, I don't want to select bun again. Store the selection in local storage.
- Show the command even if the syntax highlight isn't loaded yet. We don't need to wait for the syntax highlight to show the command. Display the command immediately, and swap it with the syntax-highlighted version once highlighting is done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Package manager selection now persists between sessions
  * Code snippets now display with syntax highlighting
  * Automatic code generation when registry URL changes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->