### PR TITLE
fix: gallery page improvement ( #5)

### DIFF
--- a/app/docs/[[...slug]]/page.tsx
+++ b/app/docs/[[...slug]]/page.tsx
@@ -124,6 +124,7 @@ export default async function DocPage({ params }: PageProps) {
 
 	// Check if this is the installation page
 	const isInstallationPage = slug.length === 1 && slug[0] === "installation";
+	const isGalleryPage = slug.length === 1 && slug[0] === "gallery";
 	let howToSchema = null;
 
 	if (isInstallationPage) {
@@ -203,6 +204,7 @@ export default async function DocPage({ params }: PageProps) {
 				toc={toc}
 				markdownContent={content}
 				breadcrumbs={uiBreadcrumbs}
+				fullWidth={isGalleryPage}
 			>
 				<Suspense
 					fallback={

--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -7,7 +7,7 @@ export default function DocsLayout({
 }) {
 	return (
 		<div className="border-b">
-			<div className="items-start md:grid md:grid-cols-[220px_minmax(0,1fr)] md:gap-6 lg:grid-cols-[200px_minmax(0,1fr)] lg:gap-10 px-8">
+			<div className="items-start px-8 md:grid md:grid-cols-[240px_minmax(0,1fr)] md:gap-6 lg:grid-cols-[260px_minmax(0,1fr)] lg:gap-10">
 				<DocsSidebar />
 				{children}
 			</div>

--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -7,7 +7,7 @@ export default function DocsLayout({
 }) {
 	return (
 		<div className="border-b">
-			<div className="items-start px-8 md:grid md:grid-cols-[240px_minmax(0,1fr)] md:gap-6 lg:grid-cols-[260px_minmax(0,1fr)] lg:gap-10">
+			<div className="items-start px-6 md:grid md:grid-cols-[220px_minmax(0,1fr)] md:gap-6 lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-6">
 				<DocsSidebar />
 				{children}
 			</div>

--- a/components/core/components-preview-card.tsx
+++ b/components/core/components-preview-card.tsx
@@ -6,102 +6,102 @@ import { ArrowRight02Icon, HugeiconsIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
 
 interface ComponentPreviewCardProps {
-  componentName: string;
-  title: string;
-  href: string;
-  className?: string;
+	componentName: string;
+	title: string;
+	href: string;
+	className?: string;
 }
 
 export const ComponentPreviewCard: FC<ComponentPreviewCardProps> = ({
-  componentName,
-  title,
-  href,
-  className,
+	componentName,
+	title,
+	href,
+	className,
 }) => {
-  const [PreviewComponent, setPreviewComponent] = useState<FC | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+	const [PreviewComponent, setPreviewComponent] = useState<FC | null>(null);
+	const [isLoading, setIsLoading] = useState(true);
 
-  useEffect(() => {
-    let mounted = true;
+	useEffect(() => {
+		let mounted = true;
 
-    async function loadComponent() {
-      setIsLoading(true);
-      try {
-        const module = await import(
-          `@/components/previews/${componentName}/default`
-        );
-        if (mounted) {
-          setPreviewComponent(() => module.default);
-        }
-      } catch (error) {
-        console.error(`Failed to load preview for ${componentName}`, error);
-      } finally {
-        if (mounted) {
-          setIsLoading(false);
-        }
-      }
-    }
+		async function loadComponent() {
+			setIsLoading(true);
+			try {
+				const module = await import(
+					`@/components/previews/${componentName}/default`
+				);
+				if (mounted) {
+					setPreviewComponent(() => module.default);
+				}
+			} catch (error) {
+				console.error(`Failed to load preview for ${componentName}`, error);
+			} finally {
+				if (mounted) {
+					setIsLoading(false);
+				}
+			}
+		}
 
-    loadComponent();
+		loadComponent();
 
-    return () => {
-      mounted = false;
-    };
-  }, [componentName]);
+		return () => {
+			mounted = false;
+		};
+	}, [componentName]);
 
-  return (
-    <div className={cn("group relative flex flex-col gap-2", className)}>
-      {/* Preview Area */}
-      <div className="relative w-full overflow-hidden rounded-xl transition-all duration-300 aspect-video">
-        {isLoading ? (
-          <div className="absolute inset-0 flex items-center justify-center">
-            <div className="h-6 w-6 animate-spin rounded-full border-2 border-muted-foreground/20 border-t-muted-foreground" />
-          </div>
-        ) : PreviewComponent ? (
-          <div
-            className="absolute inset-0 origin-top-left"
-            style={{
-              width: "166.67%",
-              height: "166.67%",
-              transform: "scale(0.6)",
-            }}
-          >
-            <div className="flex h-full w-full items-center justify-center p-4 pointer-events-none">
-              <PreviewComponent />
-            </div>
-          </div>
-        ) : (
-          <div className="absolute inset-0 flex items-center justify-center text-sm text-muted-foreground">
-            Preview not available
-          </div>
-        )}
+	return (
+		<div className={cn("group relative flex flex-col gap-2", className)}>
+			{/* Preview Area */}
+			<div className="relative w-full overflow-hidden rounded-xl transition-all duration-300 aspect-video focus-within:outline-none focus-within:ring-2 focus-within:ring-ring">
+				{isLoading ? (
+					<div className="absolute inset-0 flex items-center justify-center">
+						<div className="h-6 w-6 animate-spin rounded-full border-2 border-muted-foreground/20 border-t-muted-foreground" />
+					</div>
+				) : PreviewComponent ? (
+					<div
+						className="absolute inset-0 origin-top-left"
+						style={{
+							width: "166.67%",
+							height: "166.67%",
+							transform: "scale(0.6)",
+						}}
+					>
+						<div className="flex h-full w-full items-center justify-center p-4 pointer-events-none">
+							<PreviewComponent />
+						</div>
+					</div>
+				) : (
+					<div className="absolute inset-0 flex items-center justify-center text-sm text-muted-foreground">
+						Preview not available
+					</div>
+				)}
 
-        <Link
-          href={href}
-          aria-label={`View ${title} component docs`}
-          className="absolute inset-0 z-[3] rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        >
-          <span className="sr-only">View {title} component docs</span>
-        </Link>
+				<Link
+					href={href}
+					aria-label={`View ${title} component docs`}
+					className="absolute inset-0 z-[3] rounded-xl focus-visible:outline-none"
+				>
+					<span className="sr-only">View {title} component docs</span>
+				</Link>
 
-        {/* Hover Overlay with Title */}
-        <div
-          className="pointer-events-none absolute inset-x-0 bottom-0 z-[2] flex items-end px-4 pb-4 pt-12 opacity-0 transition-opacity duration-300 group-hover:opacity-100 group-focus-within:opacity-100 bg-gradient-to-t from-black/60 via-black/40 to-transparent backdrop-blur-md"
-          style={{
-            maskImage: "linear-gradient(to top, black, transparent)",
-            WebkitMaskImage: "linear-gradient(to top, black, transparent)",
-          }}
-        >
-          <div className="flex w-full items-center justify-between text-white">
-            <span className="text-sm font-medium z-[3]">{title}</span>
-            <HugeiconsIcon
-              icon={ArrowRight02Icon}
-              size={16}
-              className="text-white/80 transition-transform duration-300 group-hover:translate-x-0.5"
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+				{/* Hover Overlay with Title */}
+				<div
+					className="pointer-events-none absolute inset-x-0 bottom-0 z-[2] flex items-end px-4 pb-4 pt-12 opacity-0 transition-opacity duration-300 group-hover:opacity-100 group-focus-within:opacity-100 bg-gradient-to-t from-black/60 via-black/40 to-transparent backdrop-blur-md"
+					style={{
+						maskImage: "linear-gradient(to top, black, transparent)",
+						WebkitMaskImage: "linear-gradient(to top, black, transparent)",
+					}}
+				>
+					<div className="flex w-full items-center justify-between text-white">
+						<span className="text-sm font-medium">{title}</span>
+						<HugeiconsIcon
+							icon={ArrowRight02Icon}
+							size={16}
+							className="text-white/80 transition-transform duration-300 group-hover:translate-x-0.5"
+						/>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
 };

--- a/components/core/components-preview-card.tsx
+++ b/components/core/components-preview-card.tsx
@@ -50,10 +50,7 @@ export const ComponentPreviewCard: FC<ComponentPreviewCardProps> = ({
   }, [componentName]);
 
   return (
-    <Link
-      href={href}
-      className={cn("group relative flex flex-col gap-2", className)}
-    >
+    <div className={cn("group relative flex flex-col gap-2", className)}>
       {/* Preview Area */}
       <div className="relative w-full overflow-hidden rounded-xl transition-all duration-300 aspect-video">
         {isLoading ? (
@@ -79,9 +76,17 @@ export const ComponentPreviewCard: FC<ComponentPreviewCardProps> = ({
           </div>
         )}
 
+        <Link
+          href={href}
+          aria-label={`View ${title} component docs`}
+          className="absolute inset-0 z-[3] rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <span className="sr-only">View {title} component docs</span>
+        </Link>
+
         {/* Hover Overlay with Title */}
         <div
-          className="absolute inset-x-0 bottom-0 flex items-end px-4 pb-4 pt-12 opacity-0 transition-opacity duration-300 group-hover:opacity-100 bg-gradient-to-t from-black/60 via-black/40 to-transparent backdrop-blur-md"
+          className="pointer-events-none absolute inset-x-0 bottom-0 z-[2] flex items-end px-4 pb-4 pt-12 opacity-0 transition-opacity duration-300 group-hover:opacity-100 group-focus-within:opacity-100 bg-gradient-to-t from-black/60 via-black/40 to-transparent backdrop-blur-md"
           style={{
             maskImage: "linear-gradient(to top, black, transparent)",
             WebkitMaskImage: "linear-gradient(to top, black, transparent)",
@@ -97,6 +102,6 @@ export const ComponentPreviewCard: FC<ComponentPreviewCardProps> = ({
           </div>
         </div>
       </div>
-    </Link>
+    </div>
   );
 };

--- a/components/core/doc-page-layout.tsx
+++ b/components/core/doc-page-layout.tsx
@@ -20,6 +20,7 @@ interface DocPageLayoutProps {
 	markdownContent?: string;
 	children: React.ReactNode;
 	breadcrumbs?: { title: string; href: string }[];
+	fullWidth?: boolean;
 }
 
 export function DocPageLayout({
@@ -30,15 +31,21 @@ export function DocPageLayout({
 	markdownContent,
 	children,
 	breadcrumbs = [],
+	fullWidth = false,
 }: DocPageLayoutProps) {
-	const fullMarkdown = `# ${title}\n\n${description}\n\n${
-		markdownContent || ""
-	}`;
+	const fullMarkdown = `# ${title}\n\n${description}\n\n${markdownContent || ""
+		}`;
 	const navigation = getNavigation();
 
 	return (
-		<main className="relative py-6 lg:gap-10 lg:py-8 flex-1 xl:flex xl:gap-10">
-			<div className="mx-auto w-full max-w-2xl min-w-0 flex-1">
+		<main className="relative min-w-0 py-6 lg:gap-10 lg:py-8 flex-1 xl:flex xl:gap-10">
+			<div
+				className={
+					fullWidth
+						? "w-full min-w-0 flex-1"
+						: "mx-auto w-full max-w-2xl min-w-0 flex-1"
+				}
+			>
 				{breadcrumbs.length > 0 && (
 					<nav className="flex items-center space-x-1 text-sm text-muted-foreground mb-4">
 						<Link

--- a/components/core/doc-page-layout.tsx
+++ b/components/core/doc-page-layout.tsx
@@ -33,8 +33,7 @@ export function DocPageLayout({
 	breadcrumbs = [],
 	fullWidth = false,
 }: DocPageLayoutProps) {
-	const fullMarkdown = `# ${title}\n\n${description}\n\n${markdownContent || ""
-		}`;
+	const fullMarkdown = `# ${title}\n\n${description}\n\n${markdownContent || ""}`;
 	const navigation = getNavigation();
 
 	return (
@@ -98,11 +97,13 @@ export function DocPageLayout({
 					navigation={navigation}
 				/>
 			</div>
-			<div className="hidden text-sm xl:block w-[250px] shrink-0">
-				<div className="sticky top-16 -mt-10 h-[calc(100vh-3.5rem)] overflow-hidden pt-6">
-					<TableOfContents toc={toc} />
+			{!fullWidth && toc.length > 0 && (
+				<div className="hidden text-sm xl:block w-[250px] shrink-0">
+					<div className="sticky top-16 -mt-10 h-[calc(100vh-3.5rem)] overflow-hidden pt-6">
+						<TableOfContents toc={toc} />
+					</div>
 				</div>
-			</div>
+			)}
 		</main>
 	);
 }

--- a/components/core/docs-sidebar-client.tsx
+++ b/components/core/docs-sidebar-client.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+import type { IconSvgElement } from "@hugeicons/react";
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type React from "react";
 import {
 	Download05Icon,
 	Home09Icon,
@@ -8,16 +13,11 @@ import {
 	MapsIcon,
 	ShapeCollectionIcon,
 	StatusIcon,
-	UserLove01Icon
+	UserLove01Icon,
 } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { ComponentPreviewTooltip } from "@/registry/new-york/ui/component-preview-tooltip";
 import type { NavSection } from "@/types/nav-item";
-import type { IconSvgElement } from "@hugeicons/react";
-import Image from "next/image";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import type React from "react";
 import { DiscordIcon, TwitterIcon } from "../icons/social-icons";
 
 interface DocsSidebarClientProps {
@@ -51,17 +51,17 @@ export function DocsSidebarClient({ navigation }: DocsSidebarClientProps) {
 
 	return (
 		<aside className="sticky top-14 hidden md:block w-full shrink-0 h-[calc(100vh-3.5rem)]">
-			<div className="py-10  lg:py-8 overflow-auto h-full">
+			<div className="h-full overflow-auto py-10 pr-2 lg:py-8">
 				<nav className="grid grid-flow-row auto-rows-max text-sm">
 					{navigation.map((section) => (
-						<div key={section.title} className="pb-6">
+						<div key={section.title} className="pb-7">
 							{section.title.length > 0 && section.title !== "Socials" && (
-								<h4 className="rounded-md px-2 py-1 text-xs text-muted-foreground">
+								<h4 className="rounded-md px-2.5 py-1 text-xs text-muted-foreground">
 									{section.title}
 								</h4>
 							)}
 							{section.items && (
-								<div className="grid grid-flow-row auto-rows-max gap-1">
+								<div className="grid grid-flow-row auto-rows-max gap-1.5">
 									{section.items.map((item) => {
 										const componentName = getComponentName(item.href);
 										const isComponentPage = item.href.includes("/components/");
@@ -106,7 +106,7 @@ export function DocsSidebarClient({ navigation }: DocsSidebarClientProps) {
 												href={item.href}
 												target="_blank"
 												rel="noopener noreferrer"
-												className="group flex w-fit items-center gap-1.5 text-sm rounded-md border border-transparent px-2 py-1 hover:bg-accent hover:text-accent-foreground font-medium text-foreground"
+												className="group flex w-fit items-center gap-2 rounded-md border border-transparent px-2.5 py-1.5 text-sm font-medium text-foreground hover:bg-accent hover:text-accent-foreground"
 											>
 												{linkContent}
 											</a>
@@ -114,7 +114,7 @@ export function DocsSidebarClient({ navigation }: DocsSidebarClientProps) {
 											<Link
 												href={item.href}
 												className={cn(
-													"group flex w-fit items-center gap-1.5 text-sm rounded-md border border-transparent px-2 py-1 hover:bg-accent hover:text-accent-foreground font-medium text-foreground",
+													"group flex w-fit items-center gap-2 rounded-md border border-transparent px-2.5 py-1.5 text-sm font-medium text-foreground hover:bg-accent hover:text-accent-foreground",
 													pathname === item.href ? "bg-accent" : "",
 												)}
 											>

--- a/components/core/docs-sidebar-client.tsx
+++ b/components/core/docs-sidebar-client.tsx
@@ -50,7 +50,7 @@ export function DocsSidebarClient({ navigation }: DocsSidebarClientProps) {
 	};
 
 	return (
-		<aside className="sticky top-14 hidden md:block w-full md:w-[220px] lg:w-[240px] shrink-0 h-[calc(100vh-3.5rem)]">
+		<aside className="sticky top-14 hidden md:block w-full shrink-0 h-[calc(100vh-3.5rem)]">
 			<div className="py-10  lg:py-8 overflow-auto h-full">
 				<nav className="grid grid-flow-row auto-rows-max text-sm">
 					{navigation.map((section) => (

--- a/components/core/gallery-page.tsx
+++ b/components/core/gallery-page.tsx
@@ -3,9 +3,9 @@ import { getPreviewComponent } from "@/components/previews";
 import { cn } from "@/lib/utils";
 import { getComponentsMetadata } from "@/lib/utils/get-component-metadata";
 
-// Keep this list aligned with the canonical registry metadata from getComponentsMetadata().
-// Add entries when a component should render in the gallery preview grid, preferring registry-driven data where possible.
-const GALLERY_PREVIEW_COMPONENTS = [
+// Components in this list are shown first in this exact order.
+// Components not listed here are added after this list.
+const PRIORITY_GALLERY_COMPONENTS = [
     "author-tooltip",
     "github-stars-button",
     "nested-menu",
@@ -25,6 +25,8 @@ const GALLERY_PREVIEW_COMPONENTS = [
     "wave-spinner",
     "search-results-tabs",
     "link-preview",
+    "model-selector",
+    "workflow-card",
 ] as const;
 
 const DESKTOP_GALLERY_COMPONENTS = [
@@ -43,16 +45,18 @@ const DESKTOP_GALLERY_COMPONENTS = [
     "notification-card",
     "weather-card",
     "search-results-tabs",
+    "model-selector",
     "pricing-card",
     "wave-spinner",
     "link-preview",
     "navbar-menu",
-] as const satisfies readonly (typeof GALLERY_PREVIEW_COMPONENTS)[number][];
+    "workflow-card",
+] as const satisfies readonly (typeof PRIORITY_GALLERY_COMPONENTS)[number][];
 
 const GALLERY_CARD_SURFACE_CLASS = "dark:bg-background";
 
-// Add manual entries only when preview wiring or metadata is not fully represented in the registry source.
-// When adding new registry components, update this list (and GALLERY_PREVIEW_COMPONENTS) as needed to prevent drift.
+// Add a component here only if it is missing from registry metadata.
+// If a component is in registry metadata, it is added automatically.
 const MANUAL_GALLERY_COMPONENTS = [
     {
         name: "notification-card",
@@ -67,6 +71,20 @@ const MANUAL_GALLERY_COMPONENTS = [
         description:
             "An interactive todo row with priority, labels, and subtasks.",
         firstPreview: "todo-item/default",
+    },
+    {
+        name: "model-selector",
+        title: "Model Selector",
+        description:
+            "A dropdown selector for choosing AI models with provider information and pro badges.",
+        firstPreview: "model-selector/default",
+    },
+    {
+        name: "workflow-card",
+        title: "Workflow Card",
+        description:
+            "A card component for displaying workflow templates with icons and descriptions.",
+        firstPreview: "workflow-card/default",
     },
 ] as const;
 
@@ -84,7 +102,20 @@ export async function GalleryPage() {
         }
     }
 
-    const previewNames = new Set<string>(GALLERY_PREVIEW_COMPONENTS);
+    const priorityNames = new Set<string>(PRIORITY_GALLERY_COMPONENTS);
+
+    // New components added to registry.json that are NOT in PRIORITY_GALLERY_COMPONENTS
+    // will automatically appear at the bottom of the gallery.
+    const appendedComponentNames = components
+        .map((component) => component.name)
+        .filter((name) => !priorityNames.has(name));
+
+    const galleryComponentNames = [
+        ...PRIORITY_GALLERY_COMPONENTS,
+        ...appendedComponentNames,
+    ] as const;
+
+    const previewNames = new Set<string>(galleryComponentNames);
     const previewComponents = components.filter((component) =>
         previewNames.has(component.name),
     );
@@ -121,6 +152,13 @@ export async function GalleryPage() {
 
     const renderCard = (name: string, previewWidthClassName?: string) => {
         const item = previewMap.get(name);
+        const allowOverflowPreview =
+            name === "composer" || name === "model-selector";
+        const shouldLeftAlignPreview = name === "navbar-menu";
+        const previewAlignmentClass = shouldLeftAlignPreview
+            ? "items-start justify-start"
+            : "items-center justify-center";
+
         if (!item) {
             if (!warnedMissingPreviews.has(name)) {
                 console.warn(
@@ -137,9 +175,10 @@ export async function GalleryPage() {
                 >
                     <div
                         className={cn(
-                            "relative flex w-full min-w-0 items-center justify-center rounded-xl border border-dashed border-zinc-300 bg-zinc-50 p-4 dark:border-zinc-700",
+                            "relative flex w-full min-w-0 rounded-xl border border-dashed border-zinc-300 bg-zinc-50 p-4 dark:border-zinc-700",
+                            previewAlignmentClass,
                             GALLERY_CARD_SURFACE_CLASS,
-                            name === "composer"
+                            allowOverflowPreview
                                 ? "overflow-visible"
                                 : "overflow-hidden",
                         )}
@@ -186,9 +225,10 @@ export async function GalleryPage() {
                 </div>
                 <div
                     className={cn(
-                        "relative flex w-full min-w-0 items-center justify-center rounded-xl border border-zinc-200 bg-white p-4 dark:border-transparent",
+                        "relative flex w-full min-w-0 rounded-xl border border-zinc-200 bg-white p-4 dark:border-transparent",
+                        previewAlignmentClass,
                         GALLERY_CARD_SURFACE_CLASS,
-                        name === "composer"
+                        allowOverflowPreview
                             ? "overflow-visible"
                             : "overflow-hidden",
                     )}
@@ -207,6 +247,7 @@ export async function GalleryPage() {
     };
 
     const desktopRenderedNames = new Set<string>();
+    const desktopCuratedNames = new Set<string>(DESKTOP_GALLERY_COMPONENTS);
     const renderDesktopCard = (
         name: (typeof DESKTOP_GALLERY_COMPONENTS)[number],
         previewWidthClassName?: string,
@@ -259,12 +300,24 @@ export async function GalleryPage() {
                 <div className="flex flex-col gap-3">
                     {renderDesktopCard("wave-spinner")}
                     {renderDesktopCard("link-preview")}
+                    {renderDesktopCard(
+                        "model-selector",
+                        "mx-auto w-full max-w-xs",
+                    )}
                 </div>
             </div>
 
-            <div className="grid grid-cols-1 gap-3">
-                {renderDesktopCard("navbar-menu")}
+            <div className="grid grid-cols-2 gap-3">
+                {renderDesktopCard("navbar-menu", "mx-0 w-fit")}
+                {renderDesktopCard("workflow-card", "mx-auto w-full max-w-sm")}
             </div>
+
+            {/* New components from registry auto-appear here */}
+            {appendedComponentNames.length > 0 && (
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                    {appendedComponentNames.map((name) => renderCard(name))}
+                </div>
+            )}
         </div>
     );
 
@@ -274,32 +327,33 @@ export async function GalleryPage() {
         ) => {
             void renderCardRef;
 
-            const desktopNames = new Set<string>(DESKTOP_GALLERY_COMPONENTS);
-            const missingFromDesktopList = GALLERY_PREVIEW_COMPONENTS.filter(
-                (name) => !desktopNames.has(name),
-            );
-            const missingFromDesktopRender = GALLERY_PREVIEW_COMPONENTS.filter(
+            const missingFromDesktopRender = DESKTOP_GALLERY_COMPONENTS.filter(
                 (name) => !desktopRenderedNames.has(name),
             );
-
-            if (
-                DESKTOP_GALLERY_COMPONENTS.length !==
-                GALLERY_PREVIEW_COMPONENTS.length
-            ) {
-                throw new Error(
-                    `[GalleryPage] Desktop gallery layout is out of sync with GALLERY_PREVIEW_COMPONENTS. Update DESKTOP_GALLERY_COMPONENTS and renderCard invocations together.`,
-                );
-            }
-
-            if (missingFromDesktopList.length > 0) {
-                throw new Error(
-                    `[GalleryPage] DESKTOP_GALLERY_COMPONENTS is missing preview names: ${missingFromDesktopList.join(", ")}.`,
-                );
-            }
 
             if (missingFromDesktopRender.length > 0) {
                 throw new Error(
                     `[GalleryPage] Desktop renderCard layout is missing preview names: ${missingFromDesktopRender.join(", ")}.`,
+                );
+            }
+
+            const desktopNamesOutsideCuratedOrder =
+                DESKTOP_GALLERY_COMPONENTS.filter(
+                    (name) => !priorityNames.has(name),
+                );
+            if (desktopNamesOutsideCuratedOrder.length > 0) {
+                throw new Error(
+                    `[GalleryPage] DESKTOP_GALLERY_COMPONENTS contains names outside PRIORITY_GALLERY_COMPONENTS: ${desktopNamesOutsideCuratedOrder.join(", ")}.`,
+                );
+            }
+
+            const appendedNamesInDesktopCuratedLayout =
+                appendedComponentNames.filter((name) =>
+                    desktopCuratedNames.has(name),
+                );
+            if (appendedNamesInDesktopCuratedLayout.length > 0) {
+                throw new Error(
+                    `[GalleryPage] Appended names should not be in DESKTOP_GALLERY_COMPONENTS: ${appendedNamesInDesktopCuratedLayout.join(", ")}.`,
                 );
             }
         };
@@ -310,12 +364,14 @@ export async function GalleryPage() {
     return (
         <div className="w-full min-w-0">
             <div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2 lg:hidden">
-                {GALLERY_PREVIEW_COMPONENTS.map((name) =>
+                {galleryComponentNames.map((name) =>
                     renderCard(
                         name,
                         name === "navbar-menu" || name === "pricing-card"
                             ? "mx-auto w-full"
-                            : undefined,
+                            : name === "model-selector"
+                                ? "mx-auto w-full max-w-xs"
+                                : undefined,
                     ),
                 )}
             </div>

--- a/components/core/gallery-page.tsx
+++ b/components/core/gallery-page.tsx
@@ -1,26 +1,167 @@
+import Link from "next/link";
 import { getPreviewComponent } from "@/components/previews";
+import { cn } from "@/lib/utils";
 import { getComponentsMetadata } from "@/lib/utils/get-component-metadata";
 
+const GALLERY_PREVIEW_COMPONENTS = [
+	"author-tooltip",
+	"github-stars-button",
+	"nested-menu",
+	"navbar-menu",
+	"composer",
+	"slash-command-dropdown",
+	"todo-item",
+	"raised-button",
+	"holo-card",
+	"email-compose-card",
+	"message-bubble",
+	"knowledge-graph",
+	"tool-calls-section",
+	"notification-card",
+	"pricing-card",
+	"weather-card",
+	"wave-spinner",
+	"search-results-tabs",
+	"link-preview",
+] as const;
+
+const MANUAL_GALLERY_COMPONENTS = [
+	{
+		name: "notification-card",
+		title: "Notification Card",
+		description: "A compact notification feed with actions and status states.",
+		firstPreview: "notification-card/default",
+	},
+	{
+		name: "todo-item",
+		title: "Todo Item",
+		description: "An interactive todo row with priority, labels, and subtasks.",
+		firstPreview: "todo-item/default",
+	},
+] as const;
+
 export async function GalleryPage() {
-	const components = getComponentsMetadata();
+	const metadataComponents = getComponentsMetadata();
+	const components = [...metadataComponents];
+
+	for (const manualComponent of MANUAL_GALLERY_COMPONENTS) {
+		if (!components.some((component) => component.name === manualComponent.name)) {
+			components.push(manualComponent);
+		}
+	}
 
 	const previewPromises = components.map(async (component) => {
-		const PreviewComponent = await getPreviewComponent(component.firstPreview);
-		return { name: component.name, PreviewComponent };
+		const previewName =
+			component.name === "navbar-menu"
+				? "navbar-menu/full"
+				: component.firstPreview;
+		const PreviewComponent = await getPreviewComponent(previewName);
+		return { name: component.name, title: component.title, PreviewComponent };
 	});
 
 	const previews = await Promise.all(previewPromises);
+	const previewMap = new Map(
+		previews
+			.filter(
+				(
+					item,
+				): item is {
+					name: string;
+					title: string;
+					PreviewComponent: NonNullable<typeof item.PreviewComponent>;
+				} => Boolean(item.PreviewComponent),
+			)
+			.map((item) => [item.name, item]),
+	);
+
+	const renderCard = (name: string, previewWidthClassName?: string) => {
+		const item = previewMap.get(name);
+		if (!item) return null;
+
+		const { title, PreviewComponent } = item;
+
+		return (
+			<div
+				key={name}
+				data-component={name}
+				className="group relative isolate z-0 hover:z-20 focus-within:z-20"
+			>
+				<div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex -translate-y-full justify-center opacity-0 transition-opacity duration-150 ease-out group-hover:opacity-100 group-focus-within:opacity-100">
+					<Link
+						href={`/docs/components/${name}`}
+						className="pointer-events-none rounded-2xl border border-black/10 bg-zinc-100/95 px-4 py-2 text-sm text-zinc-700 shadow-[0_6px_20px_rgba(0,0,0,0.18)] backdrop-blur group-hover:pointer-events-auto group-focus-within:pointer-events-auto"
+					>
+						<span className="font-semibold text-zinc-800">{title}</span>
+						<span className="text-zinc-500"> · View Docs -&gt;</span>
+					</Link>
+				</div>
+				<div
+					className={cn(
+						"relative flex w-full min-w-0 items-center justify-center rounded-xl border border-zinc-200 bg-white p-4 dark:border-transparent dark:bg-[#0a0a0a]",
+						name === "composer" ? "overflow-visible" : "overflow-hidden",
+					)}
+				>
+					<div className={cn("relative z-0 w-full min-w-0", previewWidthClassName)}>
+						<PreviewComponent />
+					</div>
+				</div>
+			</div>
+		);
+	};
 
 	return (
-		<div className="grid grid-cols-2 w-full flex-wrap items-center justify-center gap-8">
-			{previews.map(
-				({ name, PreviewComponent }) =>
-					PreviewComponent && (
-						<div key={name}>
-							<PreviewComponent />
-						</div>
+		<div className="w-full min-w-0">
+			<div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2 lg:hidden">
+				{GALLERY_PREVIEW_COMPONENTS.map((name) =>
+					renderCard(
+						name,
+						name === "navbar-menu" || name === "pricing-card"
+							? "mx-auto w-full "
+							: undefined,
 					),
-			)}
+				)}
+			</div>
+
+			<div className="hidden w-full flex-col gap-3 lg:flex">
+				<div className="grid grid-cols-3 gap-3">
+					{renderCard("author-tooltip", "mx-auto w-fit")}
+					{renderCard("github-stars-button", "mx-auto w-fit")}
+					{renderCard("nested-menu", "mx-auto w-fit [&>div]:py-0")}
+				</div>
+
+				<div className="grid grid-cols-3 items-start gap-3">
+					<div className="flex flex-col gap-3">
+						{renderCard("composer")}
+						{renderCard("holo-card")}
+						{renderCard("message-bubble")}
+					</div>
+					<div className="flex flex-col gap-3">
+						{renderCard("slash-command-dropdown")}
+						{renderCard("todo-item", "w-full min-w-0 overflow-hidden")}
+						{renderCard("knowledge-graph")}
+					</div>
+					<div className="flex flex-col gap-3">
+						{renderCard("raised-button")}
+						{renderCard("email-compose-card")}
+						{renderCard("tool-calls-section")}
+						{renderCard("notification-card")}
+					</div>
+				</div>
+
+				<div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.45fr)_minmax(0,1fr)] items-start gap-3">
+					<div className="flex flex-col gap-3">
+						{renderCard("weather-card")}
+						{renderCard("search-results-tabs")}
+					</div>
+					<div>{renderCard("pricing-card", "mx-auto w-full max-w-[760px]")}</div>
+					<div className="flex flex-col gap-3">
+						{renderCard("wave-spinner")}
+						{renderCard("link-preview")}
+					</div>
+				</div>
+
+				<div className="grid grid-cols-1 gap-3">{renderCard("navbar-menu")}</div>
+			</div>
 		</div>
 	);
 }

--- a/components/core/gallery-page.tsx
+++ b/components/core/gallery-page.tsx
@@ -3,6 +3,8 @@ import { getPreviewComponent } from "@/components/previews";
 import { cn } from "@/lib/utils";
 import { getComponentsMetadata } from "@/lib/utils/get-component-metadata";
 
+// Keep this list aligned with the canonical registry metadata from getComponentsMetadata().
+// Add entries when a component should render in the gallery preview grid, preferring registry-driven data where possible.
 const GALLERY_PREVIEW_COMPONENTS = [
 	"author-tooltip",
 	"github-stars-button",
@@ -25,6 +27,8 @@ const GALLERY_PREVIEW_COMPONENTS = [
 	"link-preview",
 ] as const;
 
+// Add manual entries only when preview wiring or metadata is not fully represented in the registry source.
+// When adding new registry components, update this list (and GALLERY_PREVIEW_COMPONENTS) as needed to prevent drift.
 const MANUAL_GALLERY_COMPONENTS = [
 	{
 		name: "notification-card",
@@ -50,7 +54,12 @@ export async function GalleryPage() {
 		}
 	}
 
-	const previewPromises = components.map(async (component) => {
+	const previewNames = new Set<string>(GALLERY_PREVIEW_COMPONENTS);
+	const previewComponents = components.filter((component) =>
+		previewNames.has(component.name),
+	);
+
+	const previewPromises = previewComponents.map(async (component) => {
 		const previewName =
 			component.name === "navbar-menu"
 				? "navbar-menu/full"
@@ -74,9 +83,45 @@ export async function GalleryPage() {
 			.map((item) => [item.name, item]),
 	);
 
+	const warnedMissingPreviews = new Set<string>();
+
 	const renderCard = (name: string, previewWidthClassName?: string) => {
 		const item = previewMap.get(name);
-		if (!item) return null;
+		if (!item) {
+			if (!warnedMissingPreviews.has(name)) {
+				console.warn(`[GalleryPage] Missing preview component for "${name}".`);
+				warnedMissingPreviews.add(name);
+			}
+
+			return (
+				<div
+					key={name}
+					data-component={name}
+					className="group relative isolate z-0 hover:z-20 focus-within:z-20"
+				>
+					<div
+						className={cn(
+							"relative flex w-full min-w-0 items-center justify-center rounded-xl border border-dashed border-zinc-300 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-[#0a0a0a]",
+							name === "composer" ? "overflow-visible" : "overflow-hidden",
+						)}
+					>
+						<div
+							className={cn(
+								"relative z-0 w-full min-w-0 text-center",
+								previewWidthClassName,
+							)}
+						>
+							<p className="text-sm font-semibold text-zinc-700 dark:text-zinc-200">
+								Preview unavailable
+							</p>
+							<p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+								{name} could not be loaded.
+							</p>
+						</div>
+					</div>
+				</div>
+			);
+		}
 
 		const { title, PreviewComponent } = item;
 
@@ -86,13 +131,15 @@ export async function GalleryPage() {
 				data-component={name}
 				className="group relative isolate z-0 hover:z-20 focus-within:z-20"
 			>
-				<div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex -translate-y-full justify-center opacity-0 transition-opacity duration-150 ease-out group-hover:opacity-100 group-focus-within:opacity-100">
+				<div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex -translate-y-full justify-center text-zinc-700 opacity-0 transition-opacity duration-150 ease-out group-hover:opacity-100 group-focus-within:opacity-100 dark:text-zinc-200">
 					<Link
 						href={`/docs/components/${name}`}
-						className="pointer-events-none rounded-2xl border border-black/10 bg-zinc-100/95 px-4 py-2 text-sm text-zinc-700 shadow-[0_6px_20px_rgba(0,0,0,0.18)] backdrop-blur group-hover:pointer-events-auto group-focus-within:pointer-events-auto"
+						className="pointer-events-none rounded-2xl border border-black/10 bg-zinc-100/95 px-4 py-2 text-sm shadow-[0_6px_20px_rgba(0,0,0,0.18)] backdrop-blur group-hover:pointer-events-auto group-focus-within:pointer-events-auto dark:border-white/10 dark:bg-zinc-900/95 dark:shadow-[0_6px_20px_rgba(0,0,0,0.55)]"
 					>
-						<span className="font-semibold text-zinc-800">{title}</span>
-						<span className="text-zinc-500"> · View Docs -&gt;</span>
+						<span className="font-semibold text-zinc-800 dark:text-zinc-100">
+							{title}
+						</span>
+						<span className="text-zinc-500 dark:text-zinc-400"> · View Docs -&gt;</span>
 					</Link>
 				</div>
 				<div

--- a/components/core/gallery-page.tsx
+++ b/components/core/gallery-page.tsx
@@ -6,209 +6,321 @@ import { getComponentsMetadata } from "@/lib/utils/get-component-metadata";
 // Keep this list aligned with the canonical registry metadata from getComponentsMetadata().
 // Add entries when a component should render in the gallery preview grid, preferring registry-driven data where possible.
 const GALLERY_PREVIEW_COMPONENTS = [
-	"author-tooltip",
-	"github-stars-button",
-	"nested-menu",
-	"navbar-menu",
-	"composer",
-	"slash-command-dropdown",
-	"todo-item",
-	"raised-button",
-	"holo-card",
-	"email-compose-card",
-	"message-bubble",
-	"knowledge-graph",
-	"tool-calls-section",
-	"notification-card",
-	"pricing-card",
-	"weather-card",
-	"wave-spinner",
-	"search-results-tabs",
-	"link-preview",
+    "author-tooltip",
+    "github-stars-button",
+    "nested-menu",
+    "navbar-menu",
+    "composer",
+    "slash-command-dropdown",
+    "todo-item",
+    "raised-button",
+    "holo-card",
+    "email-compose-card",
+    "message-bubble",
+    "knowledge-graph",
+    "tool-calls-section",
+    "notification-card",
+    "pricing-card",
+    "weather-card",
+    "wave-spinner",
+    "search-results-tabs",
+    "link-preview",
 ] as const;
+
+const DESKTOP_GALLERY_COMPONENTS = [
+    "author-tooltip",
+    "github-stars-button",
+    "nested-menu",
+    "composer",
+    "holo-card",
+    "message-bubble",
+    "slash-command-dropdown",
+    "todo-item",
+    "knowledge-graph",
+    "raised-button",
+    "email-compose-card",
+    "tool-calls-section",
+    "notification-card",
+    "weather-card",
+    "search-results-tabs",
+    "pricing-card",
+    "wave-spinner",
+    "link-preview",
+    "navbar-menu",
+] as const satisfies readonly (typeof GALLERY_PREVIEW_COMPONENTS)[number][];
+
+const GALLERY_CARD_SURFACE_CLASS = "dark:bg-background";
 
 // Add manual entries only when preview wiring or metadata is not fully represented in the registry source.
 // When adding new registry components, update this list (and GALLERY_PREVIEW_COMPONENTS) as needed to prevent drift.
 const MANUAL_GALLERY_COMPONENTS = [
-	{
-		name: "notification-card",
-		title: "Notification Card",
-		description: "A compact notification feed with actions and status states.",
-		firstPreview: "notification-card/default",
-	},
-	{
-		name: "todo-item",
-		title: "Todo Item",
-		description: "An interactive todo row with priority, labels, and subtasks.",
-		firstPreview: "todo-item/default",
-	},
+    {
+        name: "notification-card",
+        title: "Notification Card",
+        description:
+            "A compact notification feed with actions and status states.",
+        firstPreview: "notification-card/default",
+    },
+    {
+        name: "todo-item",
+        title: "Todo Item",
+        description:
+            "An interactive todo row with priority, labels, and subtasks.",
+        firstPreview: "todo-item/default",
+    },
 ] as const;
 
 export async function GalleryPage() {
-	const metadataComponents = getComponentsMetadata();
-	const components = [...metadataComponents];
+    const metadataComponents = getComponentsMetadata();
+    const components = [...metadataComponents];
 
-	for (const manualComponent of MANUAL_GALLERY_COMPONENTS) {
-		if (!components.some((component) => component.name === manualComponent.name)) {
-			components.push(manualComponent);
-		}
-	}
+    for (const manualComponent of MANUAL_GALLERY_COMPONENTS) {
+        if (
+            !components.some(
+                (component) => component.name === manualComponent.name,
+            )
+        ) {
+            components.push(manualComponent);
+        }
+    }
 
-	const previewNames = new Set<string>(GALLERY_PREVIEW_COMPONENTS);
-	const previewComponents = components.filter((component) =>
-		previewNames.has(component.name),
-	);
+    const previewNames = new Set<string>(GALLERY_PREVIEW_COMPONENTS);
+    const previewComponents = components.filter((component) =>
+        previewNames.has(component.name),
+    );
 
-	const previewPromises = previewComponents.map(async (component) => {
-		const previewName =
-			component.name === "navbar-menu"
-				? "navbar-menu/full"
-				: component.firstPreview;
-		const PreviewComponent = await getPreviewComponent(previewName);
-		return { name: component.name, title: component.title, PreviewComponent };
-	});
+    const previewPromises = previewComponents.map(async (component) => {
+        const previewName =
+            component.name === "navbar-menu"
+                ? "navbar-menu/full"
+                : component.firstPreview;
+        const PreviewComponent = await getPreviewComponent(previewName);
+        return {
+            name: component.name,
+            title: component.title,
+            PreviewComponent,
+        };
+    });
 
-	const previews = await Promise.all(previewPromises);
-	const previewMap = new Map(
-		previews
-			.filter(
-				(
-					item,
-				): item is {
-					name: string;
-					title: string;
-					PreviewComponent: NonNullable<typeof item.PreviewComponent>;
-				} => Boolean(item.PreviewComponent),
-			)
-			.map((item) => [item.name, item]),
-	);
+    const previews = await Promise.all(previewPromises);
+    const previewMap = new Map(
+        previews
+            .filter(
+                (
+                    item,
+                ): item is {
+                    name: string;
+                    title: string;
+                    PreviewComponent: NonNullable<typeof item.PreviewComponent>;
+                } => Boolean(item.PreviewComponent),
+            )
+            .map((item) => [item.name, item]),
+    );
 
-	const warnedMissingPreviews = new Set<string>();
+    const warnedMissingPreviews = new Set<string>();
 
-	const renderCard = (name: string, previewWidthClassName?: string) => {
-		const item = previewMap.get(name);
-		if (!item) {
-			if (!warnedMissingPreviews.has(name)) {
-				console.warn(`[GalleryPage] Missing preview component for "${name}".`);
-				warnedMissingPreviews.add(name);
-			}
+    const renderCard = (name: string, previewWidthClassName?: string) => {
+        const item = previewMap.get(name);
+        if (!item) {
+            if (!warnedMissingPreviews.has(name)) {
+                console.warn(
+                    `[GalleryPage] Missing preview component for "${name}".`,
+                );
+                warnedMissingPreviews.add(name);
+            }
 
-			return (
-				<div
-					key={name}
-					data-component={name}
-					className="group relative isolate z-0 hover:z-20 focus-within:z-20"
-				>
-					<div
-						className={cn(
-							"relative flex w-full min-w-0 items-center justify-center rounded-xl border border-dashed border-zinc-300 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-[#0a0a0a]",
-							name === "composer" ? "overflow-visible" : "overflow-hidden",
-						)}
-					>
-						<div
-							className={cn(
-								"relative z-0 w-full min-w-0 text-center",
-								previewWidthClassName,
-							)}
-						>
-							<p className="text-sm font-semibold text-zinc-700 dark:text-zinc-200">
-								Preview unavailable
-							</p>
-							<p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
-								{name} could not be loaded.
-							</p>
-						</div>
-					</div>
-				</div>
-			);
-		}
+            return (
+                <div
+                    key={name}
+                    data-component={name}
+                    className="group relative isolate z-0 hover:z-20 focus-within:z-20"
+                >
+                    <div
+                        className={cn(
+                            "relative flex w-full min-w-0 items-center justify-center rounded-xl border border-dashed border-zinc-300 bg-zinc-50 p-4 dark:border-zinc-700",
+                            GALLERY_CARD_SURFACE_CLASS,
+                            name === "composer"
+                                ? "overflow-visible"
+                                : "overflow-hidden",
+                        )}
+                    >
+                        <div
+                            className={cn(
+                                "relative z-0 w-full min-w-0 text-center",
+                                previewWidthClassName,
+                            )}
+                        >
+                            <p className="text-sm font-semibold text-zinc-700 dark:text-zinc-200">
+                                Preview unavailable
+                            </p>
+                            <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                                {name} could not be loaded.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            );
+        }
 
-		const { title, PreviewComponent } = item;
+        const { title, PreviewComponent } = item;
 
-		return (
-			<div
-				key={name}
-				data-component={name}
-				className="group relative isolate z-0 hover:z-20 focus-within:z-20"
-			>
-				<div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex -translate-y-full justify-center text-zinc-700 opacity-0 transition-opacity duration-150 ease-out group-hover:opacity-100 group-focus-within:opacity-100 dark:text-zinc-200">
-					<Link
-						href={`/docs/components/${name}`}
-						className="pointer-events-none rounded-2xl border border-black/10 bg-zinc-100/95 px-4 py-2 text-sm shadow-[0_6px_20px_rgba(0,0,0,0.18)] backdrop-blur group-hover:pointer-events-auto group-focus-within:pointer-events-auto dark:border-white/10 dark:bg-zinc-900/95 dark:shadow-[0_6px_20px_rgba(0,0,0,0.55)]"
-					>
-						<span className="font-semibold text-zinc-800 dark:text-zinc-100">
-							{title}
-						</span>
-						<span className="text-zinc-500 dark:text-zinc-400"> · View Docs -&gt;</span>
-					</Link>
-				</div>
-				<div
-					className={cn(
-						"relative flex w-full min-w-0 items-center justify-center rounded-xl border border-zinc-200 bg-white p-4 dark:border-transparent dark:bg-[#0a0a0a]",
-						name === "composer" ? "overflow-visible" : "overflow-hidden",
-					)}
-				>
-					<div className={cn("relative z-0 w-full min-w-0", previewWidthClassName)}>
-						<PreviewComponent />
-					</div>
-				</div>
-			</div>
-		);
-	};
+        return (
+            <div
+                key={name}
+                data-component={name}
+                className="group relative isolate z-0 hover:z-20 focus-within:z-20"
+            >
+                <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex -translate-y-full justify-center text-zinc-700 opacity-0 transition-opacity duration-150 ease-out group-hover:opacity-100 group-focus-within:opacity-100 dark:text-zinc-200">
+                    <Link
+                        href={`/docs/components/${name}`}
+                        className="pointer-events-none rounded-2xl border border-black/10 bg-zinc-100/95 px-4 py-2 text-sm shadow-[0_6px_20px_rgba(0,0,0,0.18)] backdrop-blur group-hover:pointer-events-auto group-focus-within:pointer-events-auto dark:border-white/10 dark:bg-zinc-900/95 dark:shadow-[0_6px_20px_rgba(0,0,0,0.55)]"
+                    >
+                        <span className="font-semibold text-zinc-800 dark:text-zinc-100">
+                            {title}
+                        </span>
+                        <span className="text-zinc-500 dark:text-zinc-400">
+                            {" "}
+                            · View Docs -&gt;
+                        </span>
+                    </Link>
+                </div>
+                <div
+                    className={cn(
+                        "relative flex w-full min-w-0 items-center justify-center rounded-xl border border-zinc-200 bg-white p-4 dark:border-transparent",
+                        GALLERY_CARD_SURFACE_CLASS,
+                        name === "composer"
+                            ? "overflow-visible"
+                            : "overflow-hidden",
+                    )}
+                >
+                    <div
+                        className={cn(
+                            "relative z-0 w-full min-w-0",
+                            previewWidthClassName,
+                        )}
+                    >
+                        <PreviewComponent />
+                    </div>
+                </div>
+            </div>
+        );
+    };
 
-	return (
-		<div className="w-full min-w-0">
-			<div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2 lg:hidden">
-				{GALLERY_PREVIEW_COMPONENTS.map((name) =>
-					renderCard(
-						name,
-						name === "navbar-menu" || name === "pricing-card"
-							? "mx-auto w-full "
-							: undefined,
-					),
-				)}
-			</div>
+    const desktopRenderedNames = new Set<string>();
+    const renderDesktopCard = (
+        name: (typeof DESKTOP_GALLERY_COMPONENTS)[number],
+        previewWidthClassName?: string,
+    ) => {
+        desktopRenderedNames.add(name);
+        return renderCard(name, previewWidthClassName);
+    };
 
-			<div className="hidden w-full flex-col gap-3 lg:flex">
-				<div className="grid grid-cols-3 gap-3">
-					{renderCard("author-tooltip", "mx-auto w-fit")}
-					{renderCard("github-stars-button", "mx-auto w-fit")}
-					{renderCard("nested-menu", "mx-auto w-fit [&>div]:py-0")}
-				</div>
+    const desktopGallery = (
+        <div className="hidden w-full flex-col gap-3 lg:flex">
+            <div className="grid grid-cols-3 gap-3">
+                {renderDesktopCard("author-tooltip", "mx-auto w-fit")}
+                {renderDesktopCard("github-stars-button", "mx-auto w-fit")}
+                {renderDesktopCard("nested-menu", "mx-auto w-fit [&>div]:py-0")}
+            </div>
 
-				<div className="grid grid-cols-3 items-start gap-3">
-					<div className="flex flex-col gap-3">
-						{renderCard("composer")}
-						{renderCard("holo-card")}
-						{renderCard("message-bubble")}
-					</div>
-					<div className="flex flex-col gap-3">
-						{renderCard("slash-command-dropdown")}
-						{renderCard("todo-item", "w-full min-w-0 overflow-hidden")}
-						{renderCard("knowledge-graph")}
-					</div>
-					<div className="flex flex-col gap-3">
-						{renderCard("raised-button")}
-						{renderCard("email-compose-card")}
-						{renderCard("tool-calls-section")}
-						{renderCard("notification-card")}
-					</div>
-				</div>
+            <div className="grid grid-cols-3 items-start gap-3">
+                <div className="flex flex-col gap-3">
+                    {renderDesktopCard("composer")}
+                    {renderDesktopCard("holo-card")}
+                    {renderDesktopCard("message-bubble")}
+                </div>
+                <div className="flex flex-col gap-3">
+                    {renderDesktopCard("slash-command-dropdown")}
+                    {renderDesktopCard(
+                        "todo-item",
+                        "w-full min-w-0 overflow-hidden",
+                    )}
+                    {renderDesktopCard("knowledge-graph")}
+                </div>
+                <div className="flex flex-col gap-3">
+                    {renderDesktopCard("raised-button")}
+                    {renderDesktopCard("email-compose-card")}
+                    {renderDesktopCard("tool-calls-section")}
+                    {renderDesktopCard("notification-card")}
+                </div>
+            </div>
 
-				<div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.45fr)_minmax(0,1fr)] items-start gap-3">
-					<div className="flex flex-col gap-3">
-						{renderCard("weather-card")}
-						{renderCard("search-results-tabs")}
-					</div>
-					<div>{renderCard("pricing-card", "mx-auto w-full max-w-[760px]")}</div>
-					<div className="flex flex-col gap-3">
-						{renderCard("wave-spinner")}
-						{renderCard("link-preview")}
-					</div>
-				</div>
+            <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.45fr)_minmax(0,1fr)] items-start gap-3">
+                <div className="flex flex-col gap-3">
+                    {renderDesktopCard("weather-card")}
+                    {renderDesktopCard("search-results-tabs")}
+                </div>
+                <div>
+                    {renderDesktopCard(
+                        "pricing-card",
+                        "mx-auto w-full max-w-[760px]",
+                    )}
+                </div>
+                <div className="flex flex-col gap-3">
+                    {renderDesktopCard("wave-spinner")}
+                    {renderDesktopCard("link-preview")}
+                </div>
+            </div>
 
-				<div className="grid grid-cols-1 gap-3">{renderCard("navbar-menu")}</div>
-			</div>
-		</div>
-	);
+            <div className="grid grid-cols-1 gap-3">
+                {renderDesktopCard("navbar-menu")}
+            </div>
+        </div>
+    );
+
+    if (process.env.NODE_ENV !== "production") {
+        const assertDesktopGalleryCoverage = (
+            renderCardRef: typeof renderCard,
+        ) => {
+            void renderCardRef;
+
+            const desktopNames = new Set<string>(DESKTOP_GALLERY_COMPONENTS);
+            const missingFromDesktopList = GALLERY_PREVIEW_COMPONENTS.filter(
+                (name) => !desktopNames.has(name),
+            );
+            const missingFromDesktopRender = GALLERY_PREVIEW_COMPONENTS.filter(
+                (name) => !desktopRenderedNames.has(name),
+            );
+
+            if (
+                DESKTOP_GALLERY_COMPONENTS.length !==
+                GALLERY_PREVIEW_COMPONENTS.length
+            ) {
+                throw new Error(
+                    `[GalleryPage] Desktop gallery layout is out of sync with GALLERY_PREVIEW_COMPONENTS. Update DESKTOP_GALLERY_COMPONENTS and renderCard invocations together.`,
+                );
+            }
+
+            if (missingFromDesktopList.length > 0) {
+                throw new Error(
+                    `[GalleryPage] DESKTOP_GALLERY_COMPONENTS is missing preview names: ${missingFromDesktopList.join(", ")}.`,
+                );
+            }
+
+            if (missingFromDesktopRender.length > 0) {
+                throw new Error(
+                    `[GalleryPage] Desktop renderCard layout is missing preview names: ${missingFromDesktopRender.join(", ")}.`,
+                );
+            }
+        };
+
+        assertDesktopGalleryCoverage(renderCard);
+    }
+
+    return (
+        <div className="w-full min-w-0">
+            <div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2 lg:hidden">
+                {GALLERY_PREVIEW_COMPONENTS.map((name) =>
+                    renderCard(
+                        name,
+                        name === "navbar-menu" || name === "pricing-card"
+                            ? "mx-auto w-full"
+                            : undefined,
+                    ),
+                )}
+            </div>
+
+            {desktopGallery}
+        </div>
+    );
 }

--- a/components/core/gallery-page.tsx
+++ b/components/core/gallery-page.tsx
@@ -256,127 +256,102 @@ export async function GalleryPage() {
         return renderCard(name, previewWidthClassName);
     };
 
-    const desktopGallery = (
-        <div className="hidden w-full flex-col gap-3 lg:flex">
-            <div className="grid grid-cols-3 gap-3">
-                {renderDesktopCard("author-tooltip", "mx-auto w-fit")}
-                {renderDesktopCard("github-stars-button", "mx-auto w-fit")}
-                {renderDesktopCard("nested-menu", "mx-auto w-fit [&>div]:py-0")}
-            </div>
+    const gallery = (
+        <div className="w-full min-w-0">
+            {/* Single render path for all screen sizes. */}
+            <div className="flex w-full flex-col gap-3">
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                    {renderDesktopCard("author-tooltip", "mx-auto w-fit")}
+                    {renderDesktopCard("github-stars-button", "mx-auto w-fit")}
+                    {renderDesktopCard("nested-menu", "mx-auto w-fit [&>div]:py-0")}
+                </div>
 
-            <div className="grid grid-cols-3 items-start gap-3">
-                <div className="flex flex-col gap-3">
-                    {renderDesktopCard("composer")}
-                    {renderDesktopCard("holo-card")}
-                    {renderDesktopCard("message-bubble")}
+                <div className="grid grid-cols-1 items-start gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                    <div className="flex flex-col gap-3">
+                        {renderDesktopCard("composer")}
+                        {renderDesktopCard("holo-card")}
+                        {renderDesktopCard("message-bubble")}
+                    </div>
+                    <div className="flex flex-col gap-3">
+                        {renderDesktopCard("slash-command-dropdown")}
+                        {renderDesktopCard(
+                            "todo-item",
+                            "w-full min-w-0 overflow-hidden",
+                        )}
+                        {renderDesktopCard("knowledge-graph")}
+                    </div>
+                    <div className="flex flex-col gap-3">
+                        {renderDesktopCard("raised-button")}
+                        {renderDesktopCard("email-compose-card")}
+                        {renderDesktopCard("tool-calls-section")}
+                        {renderDesktopCard("notification-card")}
+                    </div>
                 </div>
-                <div className="flex flex-col gap-3">
-                    {renderDesktopCard("slash-command-dropdown")}
-                    {renderDesktopCard(
-                        "todo-item",
-                        "w-full min-w-0 overflow-hidden",
-                    )}
-                    {renderDesktopCard("knowledge-graph")}
-                </div>
-                <div className="flex flex-col gap-3">
-                    {renderDesktopCard("raised-button")}
-                    {renderDesktopCard("email-compose-card")}
-                    {renderDesktopCard("tool-calls-section")}
-                    {renderDesktopCard("notification-card")}
-                </div>
-            </div>
 
-            <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.45fr)_minmax(0,1fr)] items-start gap-3">
-                <div className="flex flex-col gap-3">
-                    {renderDesktopCard("weather-card")}
-                    {renderDesktopCard("search-results-tabs")}
+                <div className="grid grid-cols-1 items-start gap-3 sm:grid-cols-2 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.45fr)_minmax(0,1fr)]">
+                    <div className="flex flex-col gap-3">
+                        {renderDesktopCard("weather-card")}
+                        {renderDesktopCard("search-results-tabs")}
+                    </div>
+                    <div>
+                        {renderDesktopCard(
+                            "pricing-card",
+                            "mx-auto w-full max-w-[760px]",
+                        )}
+                    </div>
+                    <div className="flex flex-col gap-3">
+                        {renderDesktopCard("wave-spinner")}
+                        {renderDesktopCard("link-preview")}
+                        {renderDesktopCard(
+                            "model-selector",
+                            "mx-auto w-full max-w-xs",
+                        )}
+                    </div>
                 </div>
-                <div>
-                    {renderDesktopCard(
-                        "pricing-card",
-                        "mx-auto w-full max-w-[760px]",
-                    )}
-                </div>
-                <div className="flex flex-col gap-3">
-                    {renderDesktopCard("wave-spinner")}
-                    {renderDesktopCard("link-preview")}
-                    {renderDesktopCard(
-                        "model-selector",
-                        "mx-auto w-full max-w-xs",
-                    )}
-                </div>
-            </div>
 
-            <div className="grid grid-cols-2 gap-3">
-                {renderDesktopCard("navbar-menu", "mx-0 w-fit")}
-                {renderDesktopCard("workflow-card", "mx-auto w-full max-w-sm")}
-            </div>
-
-            {/* New components from registry auto-appear here */}
-            {appendedComponentNames.length > 0 && (
-                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
-                    {appendedComponentNames.map((name) => renderCard(name))}
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                    {renderDesktopCard("navbar-menu", "mx-0 w-fit")}
+                    {renderDesktopCard("workflow-card", "mx-auto w-full max-w-sm")}
                 </div>
-            )}
+
+                {/* New components from registry auto-appear here */}
+                {appendedComponentNames.length > 0 && (
+                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                        {appendedComponentNames.map((name) => renderCard(name))}
+                    </div>
+                )}
+            </div>
         </div>
     );
 
     if (process.env.NODE_ENV !== "production") {
-        const assertDesktopGalleryCoverage = (
-            renderCardRef: typeof renderCard,
-        ) => {
-            void renderCardRef;
-
-            const missingFromDesktopRender = DESKTOP_GALLERY_COMPONENTS.filter(
-                (name) => !desktopRenderedNames.has(name),
+        const missingFromDesktopRender = DESKTOP_GALLERY_COMPONENTS.filter(
+            (name) => !desktopRenderedNames.has(name),
+        );
+        if (missingFromDesktopRender.length > 0) {
+            throw new Error(
+                `[GalleryPage] Desktop renderCard layout is missing preview names: ${missingFromDesktopRender.join(", ")}.`,
             );
+        }
 
-            if (missingFromDesktopRender.length > 0) {
-                throw new Error(
-                    `[GalleryPage] Desktop renderCard layout is missing preview names: ${missingFromDesktopRender.join(", ")}.`,
-                );
-            }
+        const desktopNamesOutsideCuratedOrder = DESKTOP_GALLERY_COMPONENTS.filter(
+            (name) => !priorityNames.has(name),
+        );
+        if (desktopNamesOutsideCuratedOrder.length > 0) {
+            throw new Error(
+                `[GalleryPage] DESKTOP_GALLERY_COMPONENTS contains names outside PRIORITY_GALLERY_COMPONENTS: ${desktopNamesOutsideCuratedOrder.join(", ")}.`,
+            );
+        }
 
-            const desktopNamesOutsideCuratedOrder =
-                DESKTOP_GALLERY_COMPONENTS.filter(
-                    (name) => !priorityNames.has(name),
-                );
-            if (desktopNamesOutsideCuratedOrder.length > 0) {
-                throw new Error(
-                    `[GalleryPage] DESKTOP_GALLERY_COMPONENTS contains names outside PRIORITY_GALLERY_COMPONENTS: ${desktopNamesOutsideCuratedOrder.join(", ")}.`,
-                );
-            }
-
-            const appendedNamesInDesktopCuratedLayout =
-                appendedComponentNames.filter((name) =>
-                    desktopCuratedNames.has(name),
-                );
-            if (appendedNamesInDesktopCuratedLayout.length > 0) {
-                throw new Error(
-                    `[GalleryPage] Appended names should not be in DESKTOP_GALLERY_COMPONENTS: ${appendedNamesInDesktopCuratedLayout.join(", ")}.`,
-                );
-            }
-        };
-
-        assertDesktopGalleryCoverage(renderCard);
+        const appendedNamesInDesktopCuratedLayout = appendedComponentNames.filter(
+            (name) => desktopCuratedNames.has(name),
+        );
+        if (appendedNamesInDesktopCuratedLayout.length > 0) {
+            throw new Error(
+                `[GalleryPage] Appended names should not be in DESKTOP_GALLERY_COMPONENTS: ${appendedNamesInDesktopCuratedLayout.join(", ")}.`,
+            );
+        }
     }
 
-    return (
-        <div className="w-full min-w-0">
-            <div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2 lg:hidden">
-                {galleryComponentNames.map((name) =>
-                    renderCard(
-                        name,
-                        name === "navbar-menu" || name === "pricing-card"
-                            ? "mx-auto w-full"
-                            : name === "model-selector"
-                                ? "mx-auto w-full max-w-xs"
-                                : undefined,
-                    ),
-                )}
-            </div>
-
-            {desktopGallery}
-        </div>
-    );
+    return gallery;
 }

--- a/components/previews/navbar-menu/basic.tsx
+++ b/components/previews/navbar-menu/basic.tsx
@@ -23,7 +23,7 @@ export default function NavbarMenuBasic() {
 						<HugeiconsIcon
 							icon={Message01Icon}
 							size={20}
-							className="text-white"
+							className="text-zinc-900 dark:text-white"
 						/>
 					),
 				},
@@ -32,7 +32,7 @@ export default function NavbarMenuBasic() {
 					href: "/use-cases",
 					description: "Discover workflows",
 					icon: (
-						<HugeiconsIcon icon={Idea01Icon} size={20} className="text-white" />
+						<HugeiconsIcon icon={Idea01Icon} size={20} className="text-zinc-900 dark:text-white" />
 					),
 				},
 				{
@@ -43,7 +43,7 @@ export default function NavbarMenuBasic() {
 						<HugeiconsIcon
 							icon={CreditCardIcon}
 							size={20}
-							className="text-white"
+							className="text-zinc-900 dark:text-white"
 						/>
 					),
 				},
@@ -52,7 +52,7 @@ export default function NavbarMenuBasic() {
 					href: "/roadmap",
 					description: "What's coming next",
 					icon: (
-						<HugeiconsIcon icon={MapsIcon} size={20} className="text-white" />
+						<HugeiconsIcon icon={MapsIcon} size={20} className="text-zinc-900 dark:text-white" />
 					),
 				},
 			],

--- a/components/previews/navbar-menu/basic.tsx
+++ b/components/previews/navbar-menu/basic.tsx
@@ -23,7 +23,7 @@ export default function NavbarMenuBasic() {
 						<HugeiconsIcon
 							icon={Message01Icon}
 							size={20}
-							className="text-zinc-900 dark:text-white"
+							className="text-foreground"
 						/>
 					),
 				},
@@ -32,7 +32,11 @@ export default function NavbarMenuBasic() {
 					href: "/use-cases",
 					description: "Discover workflows",
 					icon: (
-						<HugeiconsIcon icon={Idea01Icon} size={20} className="text-zinc-900 dark:text-white" />
+						<HugeiconsIcon
+							icon={Idea01Icon}
+							size={20}
+							className="text-foreground"
+						/>
 					),
 				},
 				{
@@ -43,7 +47,7 @@ export default function NavbarMenuBasic() {
 						<HugeiconsIcon
 							icon={CreditCardIcon}
 							size={20}
-							className="text-zinc-900 dark:text-white"
+							className="text-foreground"
 						/>
 					),
 				},
@@ -52,7 +56,11 @@ export default function NavbarMenuBasic() {
 					href: "/roadmap",
 					description: "What's coming next",
 					icon: (
-						<HugeiconsIcon icon={MapsIcon} size={20} className="text-zinc-900 dark:text-white" />
+						<HugeiconsIcon
+							icon={MapsIcon}
+							size={20}
+							className="text-foreground"
+						/>
 					),
 				},
 			],

--- a/components/previews/navbar-menu/full.tsx
+++ b/components/previews/navbar-menu/full.tsx
@@ -37,7 +37,7 @@ export default function NavbarMenuFull() {
 						<HugeiconsIcon
 							icon={Message01Icon}
 							size={20}
-							className="text-white"
+							className="text-zinc-900 dark:text-white"
 						/>
 					),
 				},
@@ -48,7 +48,7 @@ export default function NavbarMenuFull() {
 					rowSpan: 2,
 					backgroundImage: "/media/wallpapers/meadow.webp",
 					icon: (
-						<HugeiconsIcon icon={Idea01Icon} size={20} className="text-white" />
+						<HugeiconsIcon icon={Idea01Icon} size={20} className="text-zinc-900 dark:text-white" />
 					),
 				},
 				{
@@ -59,7 +59,7 @@ export default function NavbarMenuFull() {
 						<HugeiconsIcon
 							icon={CreditCardIcon}
 							size={20}
-							className="text-white"
+							className="text-zinc-900 dark:text-white"
 						/>
 					),
 				},
@@ -68,7 +68,7 @@ export default function NavbarMenuFull() {
 					href: "/roadmap",
 					description: "See what's coming next",
 					icon: (
-						<HugeiconsIcon icon={MapsIcon} size={20} className="text-white" />
+						<HugeiconsIcon icon={MapsIcon} size={20} className="text-zinc-900 dark:text-white" />
 					),
 				},
 			],
@@ -82,7 +82,7 @@ export default function NavbarMenuFull() {
 					href: "/blog",
 					description: "Latest updates and insights",
 					icon: (
-						<HugeiconsIcon icon={PencilIcon} size={20} className="text-white" />
+						<HugeiconsIcon icon={PencilIcon} size={20} className="text-zinc-900 dark:text-white" />
 					),
 				},
 				{
@@ -90,7 +90,7 @@ export default function NavbarMenuFull() {
 					href: "/docs",
 					description: "Guides and API reference",
 					icon: (
-						<HugeiconsIcon icon={Book01Icon} size={20} className="text-white" />
+						<HugeiconsIcon icon={Book01Icon} size={20} className="text-zinc-900 dark:text-white" />
 					),
 				},
 				{
@@ -101,7 +101,7 @@ export default function NavbarMenuFull() {
 						<HugeiconsIcon
 							icon={HelpCircleIcon}
 							size={20}
-							className="text-white"
+							className="text-zinc-900 dark:text-white"
 						/>
 					),
 				},
@@ -113,7 +113,7 @@ export default function NavbarMenuFull() {
 						<HugeiconsIcon
 							icon={UserGroupIcon}
 							size={20}
-							className="text-white"
+							className="text-zinc-900 dark:text-white"
 						/>
 					),
 				},

--- a/components/previews/navbar-menu/full.tsx
+++ b/components/previews/navbar-menu/full.tsx
@@ -37,7 +37,7 @@ export default function NavbarMenuFull() {
 						<HugeiconsIcon
 							icon={Message01Icon}
 							size={20}
-							className="text-zinc-900 dark:text-white"
+							className="text-foreground"
 						/>
 					),
 				},
@@ -48,7 +48,11 @@ export default function NavbarMenuFull() {
 					rowSpan: 2,
 					backgroundImage: "/media/wallpapers/meadow.webp",
 					icon: (
-						<HugeiconsIcon icon={Idea01Icon} size={20} className="text-zinc-900 dark:text-white" />
+						<HugeiconsIcon
+							icon={Idea01Icon}
+							size={20}
+							className="text-foreground"
+						/>
 					),
 				},
 				{
@@ -59,7 +63,7 @@ export default function NavbarMenuFull() {
 						<HugeiconsIcon
 							icon={CreditCardIcon}
 							size={20}
-							className="text-zinc-900 dark:text-white"
+							className="text-foreground"
 						/>
 					),
 				},
@@ -68,7 +72,11 @@ export default function NavbarMenuFull() {
 					href: "/roadmap",
 					description: "See what's coming next",
 					icon: (
-						<HugeiconsIcon icon={MapsIcon} size={20} className="text-zinc-900 dark:text-white" />
+						<HugeiconsIcon
+							icon={MapsIcon}
+							size={20}
+							className="text-foreground"
+						/>
 					),
 				},
 			],
@@ -82,7 +90,11 @@ export default function NavbarMenuFull() {
 					href: "/blog",
 					description: "Latest updates and insights",
 					icon: (
-						<HugeiconsIcon icon={PencilIcon} size={20} className="text-zinc-900 dark:text-white" />
+						<HugeiconsIcon
+							icon={PencilIcon}
+							size={20}
+							className="text-foreground"
+						/>
 					),
 				},
 				{
@@ -90,7 +102,11 @@ export default function NavbarMenuFull() {
 					href: "/docs",
 					description: "Guides and API reference",
 					icon: (
-						<HugeiconsIcon icon={Book01Icon} size={20} className="text-zinc-900 dark:text-white" />
+						<HugeiconsIcon
+							icon={Book01Icon}
+							size={20}
+							className="text-foreground"
+						/>
 					),
 				},
 				{
@@ -101,7 +117,7 @@ export default function NavbarMenuFull() {
 						<HugeiconsIcon
 							icon={HelpCircleIcon}
 							size={20}
-							className="text-zinc-900 dark:text-white"
+							className="text-foreground"
 						/>
 					),
 				},
@@ -113,7 +129,7 @@ export default function NavbarMenuFull() {
 						<HugeiconsIcon
 							icon={UserGroupIcon}
 							size={20}
-							className="text-zinc-900 dark:text-white"
+							className="text-foreground"
 						/>
 					),
 				},

--- a/components/previews/notification-card/default.tsx
+++ b/components/previews/notification-card/default.tsx
@@ -72,7 +72,7 @@ export default function NotificationCardDefault() {
 	];
 
 	return (
-		<div className="flex flex-col gap-3 w-full max-w-md">
+		<div className="mx-auto flex w-full max-w-md flex-col gap-3">
 			{notifications.map((notification) => (
 				<NotificationCard
 					key={notification.id}

--- a/components/previews/raised-button/default.tsx
+++ b/components/previews/raised-button/default.tsx
@@ -4,12 +4,12 @@ import { RaisedButton } from "@/registry/new-york/ui/raised-button";
 
 export default function RaisedButtonDefault() {
 	return (
-		<>
+		<div className="flex w-full flex-wrap items-center justify-center gap-2">
 			<RaisedButton>Default</RaisedButton>
 			<RaisedButton color="#3b82f6">Blue</RaisedButton>
 			<RaisedButton color="#ef4444">Red</RaisedButton>
 			<RaisedButton color="#10b981">Green</RaisedButton>
 			<RaisedButton color="#8b5cf6">Purple</RaisedButton>
-		</>
+		</div>
 	);
 }

--- a/components/previews/slash-command-dropdown/default.tsx
+++ b/components/previews/slash-command-dropdown/default.tsx
@@ -63,8 +63,7 @@ export default function SlashCommandDropdownPreview() {
 		score: 1,
 	}));
 
-	const handleSelect = (match: SlashCommandMatch) => {
-		console.log("Selected:", match.tool.name);
+	const handleSelect = () => {
 		setIsVisible(false);
 	};
 
@@ -72,9 +71,9 @@ export default function SlashCommandDropdownPreview() {
 		setIsVisible(!isVisible);
 	};
 
-		return (
-			<div className="w-full h-[400px] relative flex items-center justify-center bg-white dark:bg-zinc-950 p-6 rounded-3xl border border-zinc-200 dark:border-zinc-800">
-				<div className="flex flex-col items-center gap-4">
+	return (
+		<div className="w-full h-[400px] relative flex items-center justify-center bg-white dark:bg-zinc-950 p-6 rounded-3xl border border-zinc-200 dark:border-zinc-800">
+			<div className="flex flex-col items-center gap-4">
 				<p className="text-zinc-400 text-sm mb-4">
 					Click the button to open the tool menu
 				</p>

--- a/components/previews/slash-command-dropdown/default.tsx
+++ b/components/previews/slash-command-dropdown/default.tsx
@@ -72,9 +72,9 @@ export default function SlashCommandDropdownPreview() {
 		setIsVisible(!isVisible);
 	};
 
-	return (
-		<div className="w-full h-[400px] relative flex items-center justify-center bg-zinc-950 p-6 rounded-3xl border border-zinc-800">
-			<div className="flex flex-col items-center gap-4">
+		return (
+			<div className="w-full h-[400px] relative flex items-center justify-center bg-white dark:bg-zinc-950 p-6 rounded-3xl border border-zinc-200 dark:border-zinc-800">
+				<div className="flex flex-col items-center gap-4">
 				<p className="text-zinc-400 text-sm mb-4">
 					Click the button to open the tool menu
 				</p>

--- a/components/ui/navbar.tsx
+++ b/components/ui/navbar.tsx
@@ -111,7 +111,7 @@ export function Navbar({ navigation }: NavbarProps) {
                     )}
                   >
                     <div className="flex items-center gap-2 font-medium">
-                      <span className="text-zinc-900 opacity-100 dark:text-white">
+                      <span className="text-zinc-900 dark:text-white">
                         GAIA
                       </span>
                       <HugeiconsIcon

--- a/components/ui/navbar.tsx
+++ b/components/ui/navbar.tsx
@@ -107,11 +107,13 @@ export function Navbar({ navigation }: NavbarProps) {
                     href={siteConfig.links.gaia}
                     className={cn(
                       navigationMenuTriggerStyle(),
-                      "text-foreground/60",
+                      "text-foreground",
                     )}
                   >
                     <div className="flex items-center gap-2 font-medium">
-                      <span>GAIA</span>
+                      <span className="text-zinc-900 opacity-100 dark:text-white">
+                        GAIA
+                      </span>
                       <HugeiconsIcon
                         icon={LinkSquare02Icon}
                         width={12}

--- a/components/ui/navbar.tsx
+++ b/components/ui/navbar.tsx
@@ -1,15 +1,19 @@
 "use client";
 
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import * as React from "react";
 import { CommandMenu } from "@/components/core/command-menu";
 import { HugeiconsIcon, LinkSquare02Icon, StarIcon } from "@/components/icons";
 import { GitHub } from "@/components/icons/github";
 import { Button } from "@/components/ui/button";
 import {
-  NavigationMenu,
-  NavigationMenuItem,
-  NavigationMenuLink,
-  NavigationMenuList,
-  navigationMenuTriggerStyle,
+    NavigationMenu,
+    NavigationMenuItem,
+    NavigationMenuLink,
+    NavigationMenuList,
+    navigationMenuTriggerStyle,
 } from "@/components/ui/navigation-menu";
 import { Separator } from "@/components/ui/separator";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
@@ -17,188 +21,203 @@ import { useGitHubStars } from "@/hooks/use-github-stars";
 import { siteConfig } from "@/lib/siteConfig";
 import { cn } from "@/lib/utils";
 import type { NavSection } from "@/types/nav-item";
-import Image from "next/image";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import * as React from "react";
 import { Kbd, KbdGroup } from "./kbd";
 
 interface NavbarProps {
-  navigation: NavSection[];
+    navigation: NavSection[];
 }
 
 export function Navbar({ navigation }: NavbarProps) {
-  const pathname = usePathname();
-  const [open, setOpen] = React.useState(false);
-  const { data: stars } = useGitHubStars();
+    const pathname = usePathname();
+    const [open, setOpen] = React.useState(false);
+    const { data: stars } = useGitHubStars();
 
-  return (
-    <header className="sticky top-0 z-50 w-full bg-background">
-      <div className="container flex py-3  max-w-screen-2xl items-center px-6">
-        <div className="mr-4 flex">
-          <Link
-            href="/"
-            className="mr-6 flex items-center space-x-2 hover:bg-muted-foreground/20 p-1 rounded-lg"
-          >
-            <Image
-              src={"/media/gaiaui_logo.png"}
-              alt="Logo"
-              width={40}
-              height={40}
-              className="aspect-auto"
-            />
-          </Link>
-          <NavigationMenu className="hidden md:flex">
-            <NavigationMenuList>
-              <NavigationMenuItem>
-                <NavigationMenuLink asChild>
-                  <Link
-                    href="/docs"
-                    className={cn(
-                      navigationMenuTriggerStyle(),
-                      pathname?.startsWith("/docs")
-                        ? "text-foreground"
-                        : "text-foreground/60",
-                    )}
-                  >
-                    Documentation
-                  </Link>
-                </NavigationMenuLink>
-              </NavigationMenuItem>
-              <NavigationMenuItem>
-                <NavigationMenuLink asChild>
-                  <Link
-                    href="/docs/components"
-                    className={cn(
-                      navigationMenuTriggerStyle(),
-                      pathname?.startsWith("/docs/components")
-                        ? "text-foreground"
-                        : "text-foreground/60",
-                    )}
-                  >
-                    Components
-                  </Link>
-                </NavigationMenuLink>
-              </NavigationMenuItem>
-              <NavigationMenuItem>
-                <NavigationMenuLink asChild>
-                  <Link
-                    href={siteConfig.links["feature-request"]}
-                    className={cn(
-                      navigationMenuTriggerStyle(),
-                      "text-foreground/60",
-                    )}
-                  >
-                    <div className="flex items-center gap-2">
-                      <span>Component Request</span>
-                      <HugeiconsIcon
-                        icon={LinkSquare02Icon}
-                        width={12}
-                        height={12}
-                        // className="absolute top-1 -right-1"
-                      />
-                    </div>
-                  </Link>
-                </NavigationMenuLink>
-              </NavigationMenuItem>
-              <NavigationMenuItem>
-                <NavigationMenuLink asChild>
-                  <Link
-                    href={siteConfig.links.gaia}
-                    className={cn(
-                      navigationMenuTriggerStyle(),
-                      "text-foreground",
-                    )}
-                  >
-                    <div className="flex items-center gap-2 font-medium">
-                      <span className="text-zinc-900 dark:text-white">
-                        GAIA
-                      </span>
-                      <HugeiconsIcon
-                        icon={LinkSquare02Icon}
-                        width={12}
-                        height={12}
-                      />
-                    </div>
-                  </Link>
-                </NavigationMenuLink>
-              </NavigationMenuItem>
-            </NavigationMenuList>
-          </NavigationMenu>
-        </div>
-        <div className="flex flex-1 items-center justify-between space-x-2 md:justify-end">
-          <div className="w-full flex-1 md:w-auto md:flex-none">
-            <Button
-              variant="secondary"
-              onClick={() => setOpen(true)}
-              className="py-0! h-9 text-sm"
-            >
-              <span className="hidden lg:inline-flex">
-                Search documentation...
-              </span>
-              <span className="inline-flex lg:hidden">Search...</span>
-              <KbdGroup>
-                <Kbd className="outline-muted-foreground/20 outline-1">⌘</Kbd>
-                <Kbd className="outline-muted-foreground/20 outline-1">K</Kbd>
-              </KbdGroup>
-            </Button>
-          </div>
-          <Separator orientation="vertical" className="h-6" />
-          <nav className="flex items-center gap-1">
-            <Button variant="ghost" size="sm" asChild className="h-9 gap-2">
-              <Link
-                href={siteConfig.links.github}
-                target="_blank"
-                rel="noreferrer"
-              >
-                <GitHub className="h-4 w-4" />
-                <div className="flex items-center gap-2">
-                  <HugeiconsIcon
-                    icon={StarIcon}
-                    size={20}
-                    className="text-yellow-500"
-                  />
-                  {stars != null && (
-                    <span className="text-sm font-medium">
-                      {stars.toLocaleString()}
-                    </span>
-                  )}
+    return (
+        <header className="sticky top-0 z-50 w-full bg-background">
+            <div className="container flex py-3  max-w-screen-2xl items-center px-6">
+                <div className="mr-4 flex">
+                    <Link
+                        href="/"
+                        className="mr-6 flex items-center space-x-2 hover:bg-muted-foreground/20 p-1 rounded-lg"
+                    >
+                        <Image
+                            src={"/media/gaiaui_logo.png"}
+                            alt="Logo"
+                            width={40}
+                            height={40}
+                            className="aspect-auto"
+                        />
+                    </Link>
+                    <NavigationMenu className="hidden md:flex">
+                        <NavigationMenuList>
+                            <NavigationMenuItem>
+                                <NavigationMenuLink asChild>
+                                    <Link
+                                        href="/docs"
+                                        className={cn(
+                                            navigationMenuTriggerStyle(),
+                                            pathname?.startsWith("/docs")
+                                                ? "text-foreground"
+                                                : "text-foreground/60",
+                                        )}
+                                    >
+                                        Documentation
+                                    </Link>
+                                </NavigationMenuLink>
+                            </NavigationMenuItem>
+                            <NavigationMenuItem>
+                                <NavigationMenuLink asChild>
+                                    <Link
+                                        href="/docs/components"
+                                        className={cn(
+                                            navigationMenuTriggerStyle(),
+                                            pathname?.startsWith(
+                                                "/docs/components",
+                                            )
+                                                ? "text-foreground"
+                                                : "text-foreground/60",
+                                        )}
+                                    >
+                                        Components
+                                    </Link>
+                                </NavigationMenuLink>
+                            </NavigationMenuItem>
+                            <NavigationMenuItem>
+                                <NavigationMenuLink asChild>
+                                    <Link
+                                        href={
+                                            siteConfig.links["feature-request"]
+                                        }
+                                        className={cn(
+                                            navigationMenuTriggerStyle(),
+                                            "text-foreground/60",
+                                        )}
+                                    >
+                                        <div className="flex items-center gap-2">
+                                            <span>Component Request</span>
+                                            <HugeiconsIcon
+                                                icon={LinkSquare02Icon}
+                                                width={12}
+                                                height={12}
+                                                // className="absolute top-1 -right-1"
+                                            />
+                                        </div>
+                                    </Link>
+                                </NavigationMenuLink>
+                            </NavigationMenuItem>
+                            <NavigationMenuItem>
+                                <NavigationMenuLink asChild>
+                                    <Link
+                                        href={siteConfig.links.gaia}
+                                        className={cn(
+                                            navigationMenuTriggerStyle(),
+                                            "text-foreground",
+                                        )}
+                                    >
+                                        <div className="flex items-center gap-2 font-medium">
+                                            <span>GAIA</span>
+                                            <HugeiconsIcon
+                                                icon={LinkSquare02Icon}
+                                                width={12}
+                                                height={12}
+                                            />
+                                        </div>
+                                    </Link>
+                                </NavigationMenuLink>
+                            </NavigationMenuItem>
+                        </NavigationMenuList>
+                    </NavigationMenu>
                 </div>
-                <span className="sr-only">GitHub</span>
-              </Link>
-            </Button>
-            <Separator orientation="vertical" className="h-6" />
-            <ThemeToggle />
-          </nav>
-        </div>
-      </div>
-      <CommandMenu open={open} setOpen={setOpen} navigation={navigation} />
-    </header>
-  );
+                <div className="flex flex-1 items-center justify-between space-x-2 md:justify-end">
+                    <div className="w-full flex-1 md:w-auto md:flex-none">
+                        <Button
+                            variant="secondary"
+                            onClick={() => setOpen(true)}
+                            className="py-0 h-9 text-sm"
+                        >
+                            <span className="hidden lg:inline-flex">
+                                Search documentation...
+                            </span>
+                            <span className="inline-flex lg:hidden">
+                                Search...
+                            </span>
+                            <KbdGroup>
+                                <Kbd className="outline-muted-foreground/20 outline-1">
+                                    ⌘
+                                </Kbd>
+                                <Kbd className="outline-muted-foreground/20 outline-1">
+                                    K
+                                </Kbd>
+                            </KbdGroup>
+                        </Button>
+                    </div>
+                    <Separator orientation="vertical" className="h-6" />
+                    <nav className="flex items-center gap-1">
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            asChild
+                            className="h-9 gap-2"
+                        >
+                            <Link
+                                href={siteConfig.links.github}
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                <GitHub className="h-4 w-4" />
+                                <div className="flex items-center gap-2">
+                                    <HugeiconsIcon
+                                        icon={StarIcon}
+                                        size={20}
+                                        className="text-yellow-500"
+                                    />
+                                    {stars != null && (
+                                        <span className="text-sm font-medium">
+                                            {stars.toLocaleString()}
+                                        </span>
+                                    )}
+                                </div>
+                                <span className="sr-only">GitHub</span>
+                            </Link>
+                        </Button>
+                        <Separator orientation="vertical" className="h-6" />
+                        <ThemeToggle />
+                    </nav>
+                </div>
+            </div>
+            <CommandMenu
+                open={open}
+                setOpen={setOpen}
+                navigation={navigation}
+            />
+        </header>
+    );
 }
 
 const ListItem = React.forwardRef<
-  React.ElementRef<"a">,
-  React.ComponentPropsWithoutRef<"a">
+    React.ElementRef<"a">,
+    React.ComponentPropsWithoutRef<"a">
 >(({ className, title, children, ...props }, ref) => {
-  return (
-    <li>
-      <NavigationMenuLink asChild>
-        <a
-          ref={ref}
-          className={cn(
-            "block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground",
-            className,
-          )}
-          {...props}
-        >
-          <div className="text-sm font-medium leading-none">{title}</div>
-          <p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
-            {children}
-          </p>
-        </a>
-      </NavigationMenuLink>
-    </li>
-  );
+    return (
+        <li>
+            <NavigationMenuLink asChild>
+                <a
+                    ref={ref}
+                    className={cn(
+                        "block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground",
+                        className,
+                    )}
+                    {...props}
+                >
+                    <div className="text-sm font-medium leading-none">
+                        {title}
+                    </div>
+                    <p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
+                        {children}
+                    </p>
+                </a>
+            </NavigationMenuLink>
+        </li>
+    );
 });
 ListItem.displayName = "ListItem";

--- a/registry/new-york/ui/navbar-menu.tsx
+++ b/registry/new-york/ui/navbar-menu.tsx
@@ -74,7 +74,7 @@ const ListItem = React.forwardRef<
           target={external ? "_blank" : undefined}
           rel={external ? "noopener noreferrer" : undefined}
           className={cn(
-            "group relative flex h-full min-h-18 w-full flex-col justify-center overflow-hidden rounded-2xl bg-zinc-800/0 p-3.5 leading-none no-underline outline-none transition-all duration-150 select-none hover:bg-zinc-800 hover:text-zinc-100 focus:bg-zinc-800 focus:text-zinc-100",
+            "group relative flex h-full min-h-18 w-full flex-col justify-center overflow-hidden rounded-2xl bg-zinc-100/0 p-3.5 leading-none no-underline outline-none transition-all duration-150 select-none hover:bg-zinc-100 hover:text-zinc-900 focus:bg-zinc-100 focus:text-zinc-900 dark:bg-zinc-800/0 dark:hover:bg-zinc-800 dark:hover:text-zinc-100 dark:focus:bg-zinc-800 dark:focus:text-zinc-100",
             className,
           )}
           {...props}
@@ -87,7 +87,7 @@ const ListItem = React.forwardRef<
                 alt={title}
                 className="absolute inset-0 z-0 h-full w-full object-cover transition-all group-hover:brightness-60"
               />
-              <div className="absolute inset-0 z-[1] bg-gradient-to-t from-black/90 via-black/50 to-black/20" />
+              <div className="absolute inset-0 z-[1] bg-gradient-to-t from-white/90 via-white/50 to-white/20 dark:from-black/90 dark:via-black/50 dark:to-black/20" />
             </>
           )}
           <div
@@ -101,20 +101,20 @@ const ListItem = React.forwardRef<
                 className={cn(
                   "relative flex min-h-10 min-w-10 items-center justify-center rounded-xl p-2 text-primary transition group-hover:text-zinc-300",
                   backgroundImage
-                    ? "bg-white/5 backdrop-blur group-hover:bg-white/10"
-                    : "bg-zinc-800/80 group-hover:bg-zinc-700/80",
+                    ? "bg-black/5 backdrop-blur group-hover:bg-black/10 dark:bg-white/5 dark:group-hover:bg-white/10"
+                    : "bg-zinc-100/90 group-hover:bg-zinc-200 dark:bg-zinc-800/80 dark:group-hover:bg-zinc-700/80",
                 )}
               >
                 {icon}
               </span>
             )}
-            <div className="flex h-full flex-col justify-start gap-1 leading-none font-normal text-zinc-100">
+            <div className="flex h-full flex-col justify-start gap-1 leading-none font-normal text-zinc-900 dark:text-zinc-100">
               {title}
 
               {children && (
                 <p
                   className={cn(
-                    "line-clamp-2 text-sm leading-tight font-light text-zinc-500",
+                    "line-clamp-2 text-sm leading-tight font-light text-zinc-500 dark:text-zinc-400",
                     backgroundImage && "relative z-[2]",
                   )}
                 >
@@ -148,7 +148,7 @@ export function NavbarMenu({ activeMenu, sections }: NavbarMenuProps) {
         ease: [0.19, 1, 0.15, 1.01],
       }}
       className={cn(
-        "absolute top-full left-0 z-40 w-full origin-top overflow-hidden rounded-b-2xl border-1 border-y-0 border-white/5 bg-gradient-to-b from-zinc-950 to-zinc-900/30 backdrop-blur-2xl outline-none",
+        "absolute top-full left-0 z-40 w-full origin-top overflow-hidden rounded-b-2xl border-1 border-y-0 border-zinc-200 bg-gradient-to-b from-white to-zinc-100/80 backdrop-blur-2xl outline-none dark:border-white/5 dark:from-zinc-950 dark:to-zinc-900/30",
       )}
     >
       <div className="p-6">
@@ -202,7 +202,7 @@ export function NavbarWithMenu({
   };
 
   return (
-    <div className="min-h-[350px] w-full bg-zinc-950 p-4 flex items-start justify-center transition">
+    <div className="min-h-[350px] w-full bg-zinc-100 p-4 flex items-start justify-center transition dark:bg-zinc-950">
       {/* biome-ignore lint/a11y/noStaticElementInteractions: Hover container for menu, not interactive content */}
       <div
         className="relative mx-auto w-screen max-w-4xl"
@@ -210,21 +210,30 @@ export function NavbarWithMenu({
       >
         <div
           className={cn(
-            "navbar_content flex h-14 w-full items-center justify-between border border-white/5 px-3 backdrop-blur-md transition-all",
+            "navbar_content flex h-14 w-full items-center justify-between border border-zinc-200 px-3 backdrop-blur-md transition-all dark:border-zinc-800",
             activeDropdown
-              ? "rounded-t-2xl border-b-0 bg-zinc-950"
-              : "rounded-2xl bg-zinc-900/30",
+              ? "rounded-t-2xl border-b-0 bg-white dark:bg-zinc-950"
+              : "rounded-2xl bg-white/80 dark:bg-zinc-900/30",
           )}
         >
           <div className="flex items-center gap-2 px-2">
             {logo || (
-              <Image
-                src="/media/text_w_logo_white.webp"
-                alt="Logo"
-                width={100}
-                height={30}
-                className="object-contain"
-              />
+              <>
+                <Image
+                  src="/media/logo_black.webp"
+                  alt="Logo"
+                  width={100}
+                  height={30}
+                  className="h-[30px] w-[100px] object-contain dark:hidden"
+                />
+                <Image
+                  src="/media/text_w_logo_white.webp"
+                  alt="Logo"
+                  width={100}
+                  height={30}
+                  className="hidden h-[30px] w-[100px] object-contain dark:block"
+                />
+              </>
             )}
           </div>
 
@@ -235,10 +244,10 @@ export function NavbarWithMenu({
                   type="button"
                   key={item.href}
                   className={cn(
-                    "relative flex h-9 cursor-pointer items-center rounded-xl px-4 py-2 text-sm transition-colors hover:bg-zinc-800/40",
+                    "relative flex h-9 cursor-pointer items-center rounded-xl px-4 py-2 text-sm transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-800/40",
                     hoveredItem === item.label.toLowerCase()
-                      ? "text-zinc-100"
-                      : "text-zinc-400 hover:text-zinc-100",
+                      ? "text-zinc-900 dark:text-zinc-100"
+                      : "text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100",
                   )}
                   onMouseEnter={() => {
                     setHoveredItem(item.label.toLowerCase());
@@ -251,11 +260,11 @@ export function NavbarWithMenu({
                 <button
                   type="button"
                   key={item.menu}
-                  className="relative flex h-9 cursor-pointer items-center rounded-xl px-4 py-2 text-sm text-zinc-400 capitalize transition-colors hover:text-zinc-100"
+                  className="relative flex h-9 cursor-pointer items-center rounded-xl px-4 py-2 text-sm text-zinc-500 capitalize transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
                   onMouseEnter={() => handleMouseEnter(item.menu)}
                 >
                   {hoveredItem === item.menu && (
-                    <div className="absolute inset-0 h-full w-full rounded-xl bg-zinc-800 transition-all duration-300 ease-out" />
+                    <div className="absolute inset-0 h-full w-full rounded-xl bg-zinc-100 transition-all duration-300 ease-out dark:bg-zinc-800" />
                   )}
                   <div className="relative z-10 flex items-center gap-2">
                     <span>

--- a/registry/new-york/ui/navbar-menu.tsx
+++ b/registry/new-york/ui/navbar-menu.tsx
@@ -74,7 +74,7 @@ const ListItem = React.forwardRef<
           target={external ? "_blank" : undefined}
           rel={external ? "noopener noreferrer" : undefined}
           className={cn(
-            "group relative flex h-full min-h-18 w-full flex-col justify-center overflow-hidden rounded-2xl bg-zinc-100/0 p-3.5 leading-none no-underline outline-none transition-all duration-150 select-none hover:bg-zinc-100 hover:text-zinc-900 focus:bg-zinc-100 focus:text-zinc-900 dark:bg-zinc-800/0 dark:hover:bg-zinc-800 dark:hover:text-zinc-100 dark:focus:bg-zinc-800 dark:focus:text-zinc-100",
+            "group relative flex h-full min-h-18 w-full flex-col justify-center overflow-hidden rounded-2xl bg-muted/0 p-3.5 leading-none no-underline outline-none transition-all duration-150 select-none hover:bg-muted hover:text-foreground focus:bg-muted focus:text-foreground",
             className,
           )}
           {...props}
@@ -87,7 +87,7 @@ const ListItem = React.forwardRef<
                 alt={title}
                 className="absolute inset-0 z-0 h-full w-full object-cover transition-all group-hover:brightness-60"
               />
-              <div className="absolute inset-0 z-[1] bg-gradient-to-t from-white/90 via-white/50 to-white/20 dark:from-black/90 dark:via-black/50 dark:to-black/20" />
+              <div className="absolute inset-0 z-[1] bg-gradient-to-t from-background/90 via-background/50 to-background/20" />
             </>
           )}
           <div
@@ -99,22 +99,22 @@ const ListItem = React.forwardRef<
             {icon && (
               <span
                 className={cn(
-                  "relative flex min-h-10 min-w-10 items-center justify-center rounded-xl p-2 text-primary transition group-hover:text-zinc-300",
+                  "relative flex min-h-10 min-w-10 items-center justify-center rounded-xl p-2 text-primary transition group-hover:text-foreground",
                   backgroundImage
-                    ? "bg-black/5 backdrop-blur group-hover:bg-black/10 dark:bg-white/5 dark:group-hover:bg-white/10"
-                    : "bg-zinc-100/90 group-hover:bg-zinc-200 dark:bg-zinc-800/80 dark:group-hover:bg-zinc-700/80",
+                    ? "bg-background/10 backdrop-blur group-hover:bg-background/20"
+                    : "bg-muted/90 group-hover:bg-muted",
                 )}
               >
                 {icon}
               </span>
             )}
-            <div className="flex h-full flex-col justify-start gap-1 leading-none font-normal text-zinc-900 dark:text-zinc-100">
+            <div className="flex h-full flex-col justify-start gap-1 leading-none font-normal text-foreground">
               {title}
 
               {children && (
                 <p
                   className={cn(
-                    "line-clamp-2 text-sm leading-tight font-light text-zinc-500 dark:text-zinc-400",
+                    "line-clamp-2 text-sm leading-tight font-light text-muted-foreground",
                     backgroundImage && "relative z-[2]",
                   )}
                 >
@@ -148,7 +148,7 @@ export function NavbarMenu({ activeMenu, sections }: NavbarMenuProps) {
         ease: [0.19, 1, 0.15, 1.01],
       }}
       className={cn(
-        "absolute top-full left-0 z-40 w-full origin-top overflow-hidden rounded-b-2xl border-1 border-y-0 border-zinc-200 bg-gradient-to-b from-white to-zinc-100/80 backdrop-blur-2xl outline-none dark:border-white/5 dark:from-zinc-950 dark:to-zinc-900/30",
+        "absolute top-full left-0 z-40 w-full origin-top overflow-hidden rounded-b-2xl border-1 border-y-0 border-border bg-gradient-to-b from-background to-muted/80 backdrop-blur-2xl outline-none",
       )}
     >
       <div className="p-6">
@@ -202,7 +202,7 @@ export function NavbarWithMenu({
   };
 
   return (
-    <div className="min-h-[350px] w-full bg-zinc-100 p-4 flex items-start justify-center transition dark:bg-zinc-950">
+    <div className="min-h-[350px] w-full bg-background p-4 flex items-start justify-center transition">
       {/* biome-ignore lint/a11y/noStaticElementInteractions: Hover container for menu, not interactive content */}
       <div
         className="relative mx-auto w-screen max-w-4xl"
@@ -210,10 +210,10 @@ export function NavbarWithMenu({
       >
         <div
           className={cn(
-            "navbar_content flex h-14 w-full items-center justify-between border border-zinc-200 px-3 backdrop-blur-md transition-all dark:border-zinc-800",
+            "navbar_content flex h-14 w-full items-center justify-between border border-border px-3 backdrop-blur-md transition-all",
             activeDropdown
-              ? "rounded-t-2xl border-b-0 bg-white dark:bg-zinc-950"
-              : "rounded-2xl bg-white/80 dark:bg-zinc-900/30",
+              ? "rounded-t-2xl border-b-0 bg-background"
+              : "rounded-2xl bg-background/80",
           )}
         >
           <div className="flex items-center gap-2 px-2">
@@ -244,10 +244,10 @@ export function NavbarWithMenu({
                   type="button"
                   key={item.href}
                   className={cn(
-                    "relative flex h-9 cursor-pointer items-center rounded-xl px-4 py-2 text-sm transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-800/40",
+                    "relative flex h-9 cursor-pointer items-center rounded-xl px-4 py-2 text-sm transition-colors hover:bg-muted/80",
                     hoveredItem === item.label.toLowerCase()
-                      ? "text-zinc-900 dark:text-zinc-100"
-                      : "text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100",
+                      ? "text-foreground"
+                      : "text-muted-foreground hover:text-foreground",
                   )}
                   onMouseEnter={() => {
                     setHoveredItem(item.label.toLowerCase());
@@ -260,11 +260,11 @@ export function NavbarWithMenu({
                 <button
                   type="button"
                   key={item.menu}
-                  className="relative flex h-9 cursor-pointer items-center rounded-xl px-4 py-2 text-sm text-zinc-500 capitalize transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                  className="relative flex h-9 cursor-pointer items-center rounded-xl px-4 py-2 text-sm text-muted-foreground capitalize transition-colors hover:text-foreground"
                   onMouseEnter={() => handleMouseEnter(item.menu)}
                 >
                   {hoveredItem === item.menu && (
-                    <div className="absolute inset-0 h-full w-full rounded-xl bg-zinc-100 transition-all duration-300 ease-out dark:bg-zinc-800" />
+                    <div className="absolute inset-0 h-full w-full rounded-xl bg-muted transition-all duration-300 ease-out" />
                   )}
                   <div className="relative z-10 flex items-center gap-2">
                     <span>

--- a/registry/new-york/ui/navbar-menu.tsx
+++ b/registry/new-york/ui/navbar-menu.tsx
@@ -2,6 +2,7 @@
 
 import { AnimatePresence, motion } from "motion/react";
 import Image from "next/image";
+import { useTheme } from "next-themes";
 import * as React from "react";
 import { ArrowDown01Icon, HugeiconsIcon } from "@/components/icons";
 
@@ -9,292 +10,379 @@ import { cn } from "@/lib/utils";
 import { RaisedButton } from "@/registry/new-york/ui/raised-button";
 
 export interface NavbarMenuLink {
-  label: string;
-  href: string;
-  icon?: React.ReactNode;
-  external?: boolean;
-  description?: string;
-  backgroundImage?: string;
-  rowSpan?: number;
+    label: string;
+    href: string;
+    icon?: React.ReactNode;
+    external?: boolean;
+    description?: string;
+    backgroundImage?: string;
+    rowSpan?: number;
 }
 
 export interface NavbarMenuSection {
-  id: string;
-  links: NavbarMenuLink[];
-  gridLayout?: string;
+    id: string;
+    links: NavbarMenuLink[];
+    gridLayout?: string;
 }
 
 export interface NavbarMenuProps {
-  activeMenu: string;
-  sections: NavbarMenuSection[];
-  onClose?: () => void;
+    activeMenu: string;
+    sections: NavbarMenuSection[];
+    onClose?: () => void;
 }
 
 export interface NavbarWithMenuProps {
-  sections: NavbarMenuSection[];
-  navItems?: Array<
-    | { type: "link"; label: string; href: string }
-    | { type: "dropdown"; label: string; menu: string }
-  >;
-  logo?: React.ReactNode;
-  cta?: React.ReactNode;
+    sections: NavbarMenuSection[];
+    navItems?: Array<
+        | { type: "link"; label: string; href: string }
+        | { type: "dropdown"; label: string; menu: string }
+    >;
+    logo?: React.ReactNode;
+    cta?: React.ReactNode;
 }
 
 const ListItem = React.forwardRef<
-  HTMLAnchorElement,
-  React.AnchorHTMLAttributes<HTMLAnchorElement> & {
-    title: string;
-    children?: React.ReactNode;
-    href: string;
-    external?: boolean;
-    icon?: React.ReactNode;
-    backgroundImage?: string;
-    rowSpan?: number;
-  }
+    HTMLAnchorElement,
+    React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+        title: string;
+        children?: React.ReactNode;
+        href: string;
+        external?: boolean;
+        icon?: React.ReactNode;
+        backgroundImage?: string;
+        rowSpan?: number;
+    }
 >(
-  (
-    {
-      className,
-      title,
-      children,
-      href,
-      external,
-      icon,
-      backgroundImage,
-      rowSpan,
-      ...props
-    },
-    ref,
-  ) => {
-    return (
-      <li className={cn("list-none", rowSpan === 2 && "row-span-2")}>
-        <a
-          ref={ref}
-          href={href}
-          target={external ? "_blank" : undefined}
-          rel={external ? "noopener noreferrer" : undefined}
-          className={cn(
-            "group relative flex h-full min-h-18 w-full flex-col justify-center overflow-hidden rounded-2xl bg-muted/0 p-3.5 leading-none no-underline outline-none transition-all duration-150 select-none hover:bg-muted hover:text-foreground focus:bg-muted focus:text-foreground",
+    (
+        {
             className,
-          )}
-          {...props}
-        >
-          {backgroundImage && (
-            <>
-              <Image
-                fill
-                src={backgroundImage}
-                alt={title}
-                className="absolute inset-0 z-0 h-full w-full object-cover transition-all group-hover:brightness-60"
-              />
-              <div className="absolute inset-0 z-[1] bg-gradient-to-t from-background/90 via-background/50 to-background/20" />
-            </>
-          )}
-          <div
-            className={cn(
-              "flex items-start gap-3",
-              backgroundImage && "relative z-[2] mt-auto",
-            )}
-          >
-            {icon && (
-              <span
-                className={cn(
-                  "relative flex min-h-10 min-w-10 items-center justify-center rounded-xl p-2 text-primary transition group-hover:text-foreground",
-                  backgroundImage
-                    ? "bg-background/10 backdrop-blur group-hover:bg-background/20"
-                    : "bg-muted/90 group-hover:bg-muted",
-                )}
-              >
-                {icon}
-              </span>
-            )}
-            <div className="flex h-full flex-col justify-start gap-1 leading-none font-normal text-foreground">
-              {title}
-
-              {children && (
-                <p
-                  className={cn(
-                    "line-clamp-2 text-sm leading-tight font-light text-muted-foreground",
-                    backgroundImage && "relative z-[2]",
-                  )}
+            title,
+            children,
+            href,
+            external,
+            icon,
+            backgroundImage,
+            rowSpan,
+            ...props
+        },
+        ref,
+    ) => {
+        return (
+            <li className={cn("list-none", rowSpan === 2 && "row-span-2")}>
+                <a
+                    ref={ref}
+                    href={href}
+                    target={external ? "_blank" : undefined}
+                    rel={external ? "noopener noreferrer" : undefined}
+                    className={cn(
+                        "group relative flex h-full min-h-18 w-full flex-col justify-center overflow-hidden rounded-2xl bg-muted/0 p-3.5 leading-none no-underline outline-none transition-all duration-150 select-none hover:bg-muted hover:text-foreground focus:bg-muted focus:text-foreground",
+                        className,
+                    )}
+                    {...props}
                 >
-                  {children}
-                </p>
-              )}
-            </div>
-          </div>
-        </a>
-      </li>
-    );
-  },
+                    {backgroundImage && (
+                        <>
+                            <Image
+                                fill
+                                src={backgroundImage}
+                                alt={title}
+                                className="absolute inset-0 z-0 h-full w-full object-cover transition-all group-hover:brightness-75"
+                            />
+                            <div className="absolute inset-0 z-[1] bg-gradient-to-t from-background/90 via-background/50 to-background/20" />
+                        </>
+                    )}
+                    <div
+                        className={cn(
+                            "flex items-start gap-3",
+                            backgroundImage && "relative z-[2] mt-auto",
+                        )}
+                    >
+                        {icon && (
+                            <span
+                                className={cn(
+                                    "relative flex min-h-10 min-w-10 items-center justify-center rounded-xl p-2 text-primary transition group-hover:text-foreground",
+                                    backgroundImage
+                                        ? "bg-background/10 backdrop-blur group-hover:bg-background/20"
+                                        : "bg-muted/90 group-hover:bg-muted",
+                                )}
+                            >
+                                {icon}
+                            </span>
+                        )}
+                        <div className="flex h-full flex-col justify-start gap-1 leading-none font-normal text-foreground">
+                            {title}
+
+                            {children && (
+                                <p
+                                    className={cn(
+                                        "line-clamp-2 text-sm leading-tight font-light text-muted-foreground",
+                                        backgroundImage && "relative z-[2]",
+                                    )}
+                                >
+                                    {children}
+                                </p>
+                            )}
+                        </div>
+                    </div>
+                </a>
+            </li>
+        );
+    },
 );
 
 ListItem.displayName = "ListItem";
 
 export function NavbarMenu({ activeMenu, sections }: NavbarMenuProps) {
-  const activeSection = sections.find((section) => section.id === activeMenu);
+    const activeSection = sections.find((section) => section.id === activeMenu);
 
-  if (!activeSection) return null;
+    if (!activeSection) return null;
 
-  const gridLayout =
-    activeSection.gridLayout || "grid w-full grid-cols-2 gap-4";
+    const gridLayout =
+        activeSection.gridLayout || "grid w-full grid-cols-2 gap-4";
 
-  return (
-    <motion.div
-      initial={{ scaleY: 0.95, opacity: 0 }}
-      animate={{ scaleY: 1, opacity: 1 }}
-      exit={{ scaleY: 0.95, opacity: 0 }}
-      transition={{
-        ease: [0.19, 1, 0.15, 1.01],
-      }}
-      className={cn(
-        "absolute top-full left-0 z-40 w-full origin-top overflow-hidden rounded-b-2xl border-1 border-y-0 border-border bg-gradient-to-b from-background to-muted/80 backdrop-blur-2xl outline-none",
-      )}
-    >
-      <div className="p-6">
-        <ul className={gridLayout}>
-          {activeSection.links.map((link) => (
-            <ListItem
-              key={link.href}
-              href={link.href}
-              title={link.label}
-              external={link.external}
-              icon={link.icon}
-              backgroundImage={link.backgroundImage}
-              rowSpan={link.rowSpan}
-            >
-              {link.description}
-            </ListItem>
-          ))}
-        </ul>
-      </div>
-    </motion.div>
-  );
+    return (
+        <motion.div
+            initial={{ scaleY: 0.95, opacity: 0 }}
+            animate={{ scaleY: 1, opacity: 1 }}
+            exit={{ scaleY: 0.95, opacity: 0 }}
+            transition={{
+                ease: [0.19, 1, 0.15, 1.01],
+            }}
+            className={cn(
+                "absolute top-full left-0 z-40 w-full origin-top overflow-hidden rounded-b-2xl border-1 border-y-0 border-border bg-gradient-to-b from-background to-muted/80 backdrop-blur-2xl outline-none",
+            )}
+        >
+            <div className="p-6">
+                <ul className={gridLayout}>
+                    {activeSection.links.map((link) => (
+                        <ListItem
+                            key={link.href}
+                            href={link.href}
+                            title={link.label}
+                            external={link.external}
+                            icon={link.icon}
+                            backgroundImage={link.backgroundImage}
+                            rowSpan={link.rowSpan}
+                        >
+                            {link.description}
+                        </ListItem>
+                    ))}
+                </ul>
+            </div>
+        </motion.div>
+    );
 }
 
 export function NavbarWithMenu({
-  sections,
-  navItems,
-  logo,
-  cta,
+    sections,
+    navItems,
+    logo,
+    cta,
 }: NavbarWithMenuProps) {
-  const [activeDropdown, setActiveDropdown] = React.useState<string | null>(
-    null,
-  );
-  const [hoveredItem, setHoveredItem] = React.useState<string | null>(null);
+    const { resolvedTheme } = useTheme();
+    const [activeDropdown, setActiveDropdown] = React.useState<string | null>(
+        null,
+    );
+    const [hoveredItem, setHoveredItem] = React.useState<string | null>(null);
+    const [isMounted, setIsMounted] = React.useState(false);
+    const theme = resolvedTheme ?? "light";
+    const logoSrc =
+        theme === "dark"
+            ? "/media/text_w_logo_white.webp"
+            : "/media/logo_black.webp";
 
-  const defaultNavItems = [
-    { type: "dropdown", label: "Product", menu: "product" },
-    { type: "dropdown", label: "Resources", menu: "resources" },
-    { type: "dropdown", label: "Socials", menu: "socials" },
-  ] as const;
+    React.useEffect(() => {
+        setIsMounted(true);
+    }, []);
 
-  const items = navItems || defaultNavItems;
+    // Keyboard accessibility
+    const menuButtonRefs = React.useRef<
+        (HTMLButtonElement | HTMLAnchorElement | null)[]
+    >([]);
+    const handleKeyDown = (
+        e: React.KeyboardEvent<HTMLButtonElement | HTMLAnchorElement>,
+        item:
+            | { type: "link"; label: string; href: string }
+            | { type: "dropdown"; label: string; menu: string },
+        idx: number,
+    ) => {
+        if (e.key === "Enter" || e.key === " ") {
+            if (item.type === "dropdown") {
+                e.preventDefault();
+                setActiveDropdown(item.menu);
+                setHoveredItem(item.menu);
+            } else {
+                // For links, let default anchor behavior occur
+            }
+        } else if (e.key === "Escape") {
+            handleNavbarMouseLeave();
+        } else if (e.key === "ArrowDown") {
+            e.preventDefault();
+            const nextIdx = (idx + 1) % items.length;
+            menuButtonRefs.current[nextIdx]?.focus();
+        } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            const prevIdx = (idx - 1 + items.length) % items.length;
+            menuButtonRefs.current[prevIdx]?.focus();
+        }
+    };
 
-  const handleNavbarMouseLeave = () => {
-    setActiveDropdown(null);
-    setHoveredItem(null);
-  };
+    React.useEffect(() => {
+        const onGlobalEscape = (e: KeyboardEvent) => {
+            if (e.key === "Escape") {
+                setActiveDropdown(null);
+                setHoveredItem(null);
+            }
+        };
+        window.addEventListener("keydown", onGlobalEscape);
+        return () => window.removeEventListener("keydown", onGlobalEscape);
+    }, []);
 
-  const handleMouseEnter = (menu: string) => {
-    setActiveDropdown(menu);
-    setHoveredItem(menu);
-  };
+    const defaultNavItems = [
+        { type: "dropdown", label: "Product", menu: "product" },
+        { type: "dropdown", label: "Resources", menu: "resources" },
+        { type: "dropdown", label: "Socials", menu: "socials" },
+    ] as const;
 
-  return (
-    <div className="min-h-[350px] w-full bg-background p-4 flex items-start justify-center transition">
-      {/* biome-ignore lint/a11y/noStaticElementInteractions: Hover container for menu, not interactive content */}
-      <div
-        className="relative mx-auto w-screen max-w-4xl"
-        onMouseLeave={handleNavbarMouseLeave}
-      >
-        <div
-          className={cn(
-            "navbar_content flex h-14 w-full items-center justify-between border border-border px-3 backdrop-blur-md transition-all",
-            activeDropdown
-              ? "rounded-t-2xl border-b-0 bg-background"
-              : "rounded-2xl bg-background/80",
-          )}
-        >
-          <div className="flex items-center gap-2 px-2">
-            {logo || (
-              <>
-                <Image
-                  src="/media/logo_black.webp"
-                  alt="Logo"
-                  width={100}
-                  height={30}
-                  className="h-[30px] w-[100px] object-contain dark:hidden"
-                />
-                <Image
-                  src="/media/text_w_logo_white.webp"
-                  alt="Logo"
-                  width={100}
-                  height={30}
-                  className="hidden h-[30px] w-[100px] object-contain dark:block"
-                />
-              </>
-            )}
-          </div>
+    const items = navItems || defaultNavItems;
 
-          <div className="flex items-center gap-1 rounded-lg px-1 py-1">
-            {items.map((item) =>
-              item.type === "link" ? (
-                <button
-                  type="button"
-                  key={item.href}
-                  className={cn(
-                    "relative flex h-9 cursor-pointer items-center rounded-xl px-4 py-2 text-sm transition-colors hover:bg-muted/80",
-                    hoveredItem === item.label.toLowerCase()
-                      ? "text-foreground"
-                      : "text-muted-foreground hover:text-foreground",
-                  )}
-                  onMouseEnter={() => {
-                    setHoveredItem(item.label.toLowerCase());
-                    setActiveDropdown(null);
-                  }}
+    const handleNavbarMouseLeave = () => {
+        setActiveDropdown(null);
+        setHoveredItem(null);
+    };
+
+    const handleMouseEnter = (menu: string) => {
+        setActiveDropdown(menu);
+        setHoveredItem(menu);
+    };
+
+    return (
+        <div className="min-h-[350px] w-full bg-background p-4 flex items-start justify-center transition">
+            {/* biome-ignore lint/a11y/noStaticElementInteractions: Hover container for menu, not interactive content */}
+            <div
+                className="relative mx-auto w-screen max-w-4xl"
+                onMouseLeave={handleNavbarMouseLeave}
+            >
+                <div
+                    className={cn(
+                        "navbar_content flex h-14 w-full items-center justify-between border border-border px-3 backdrop-blur-md transition-all",
+                        activeDropdown
+                            ? "rounded-t-2xl border-b-0 bg-background"
+                            : "rounded-2xl bg-background/80",
+                    )}
                 >
-                  <span className="relative z-10">{item.label}</span>
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  key={item.menu}
-                  className="relative flex h-9 cursor-pointer items-center rounded-xl px-4 py-2 text-sm text-muted-foreground capitalize transition-colors hover:text-foreground"
-                  onMouseEnter={() => handleMouseEnter(item.menu)}
-                >
-                  {hoveredItem === item.menu && (
-                    <div className="absolute inset-0 h-full w-full rounded-xl bg-muted transition-all duration-300 ease-out" />
-                  )}
-                  <div className="relative z-10 flex items-center gap-2">
-                    <span>
-                      {item.label.charAt(0).toUpperCase() + item.label.slice(1)}
-                    </span>
-                    <HugeiconsIcon
-                      icon={ArrowDown01Icon}
-                      size={17}
-                      className={cn(
-                        "transition duration-200",
-                        hoveredItem === item.menu && "rotate-180",
-                      )}
-                    />
-                  </div>
-                </button>
-              ),
-            )}
-          </div>
+                    <div className="flex items-center gap-2 px-2">
+                        {logo ||
+                            (isMounted && (
+                                <Image
+                                    src={logoSrc}
+                                    alt="Logo"
+                                    width={100}
+                                    height={30}
+                                    className="h-[30px] w-[100px] object-contain"
+                                />
+                            ))}
+                    </div>
 
-          <div className="flex items-center gap-2">
-            {cta || <RaisedButton color="#00bbff">Get Started</RaisedButton>}
-          </div>
+                    <div className="flex items-center gap-1 rounded-lg px-1 py-1">
+                        {items.map((item, idx) =>
+                            item.type === "link" ? (
+                                <a
+                                    ref={(el) => {
+                                        menuButtonRefs.current[idx] = el;
+                                    }}
+                                    key={item.href}
+                                    href={item.href}
+                                    className={cn(
+                                        "relative flex h-9 cursor-pointer items-center rounded-xl px-4 py-2 text-sm transition-colors hover:bg-muted/80",
+                                        hoveredItem === item.label.toLowerCase()
+                                            ? "text-foreground"
+                                            : "text-muted-foreground hover:text-foreground",
+                                    )}
+                                    onMouseEnter={() => {
+                                        setHoveredItem(
+                                            item.label.toLowerCase(),
+                                        );
+                                        setActiveDropdown(null);
+                                    }}
+                                    onKeyDown={(e) =>
+                                        handleKeyDown(e, item, idx)
+                                    }
+                                    role="menuitem"
+                                    tabIndex={0}
+                                    // Only add target/rel if item has external property
+                                    {...("external" in item && item.external
+                                        ? {
+                                              target: "_blank",
+                                              rel: "noopener noreferrer",
+                                          }
+                                        : {})}
+                                >
+                                    <span className="relative z-10">
+                                        {item.label}
+                                    </span>
+                                </a>
+                            ) : (
+                                <button
+                                    ref={(el) => {
+                                        menuButtonRefs.current[idx] = el;
+                                    }}
+                                    type="button"
+                                    key={item.menu}
+                                    className="relative flex h-9 cursor-pointer items-center rounded-xl px-4 py-2 text-sm text-muted-foreground capitalize transition-colors hover:text-foreground"
+                                    onMouseEnter={() =>
+                                        handleMouseEnter(item.menu)
+                                    }
+                                    onKeyDown={(e) =>
+                                        handleKeyDown(e, item, idx)
+                                    }
+                                    role="menuitem"
+                                    tabIndex={0}
+                                    aria-expanded={activeDropdown === item.menu}
+                                >
+                                    {hoveredItem === item.menu && (
+                                        <div className="absolute inset-0 h-full w-full rounded-xl bg-muted transition-all duration-300 ease-out" />
+                                    )}
+                                    <div className="relative z-10 flex items-center gap-2">
+                                        <span>
+                                            {item.label
+                                                .charAt(0)
+                                                .toUpperCase() +
+                                                item.label.slice(1)}
+                                        </span>
+                                        <HugeiconsIcon
+                                            icon={ArrowDown01Icon}
+                                            size={17}
+                                            className={cn(
+                                                "transition duration-200",
+                                                hoveredItem === item.menu &&
+                                                    "rotate-180",
+                                            )}
+                                        />
+                                    </div>
+                                </button>
+                            ),
+                        )}
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                        {cta || (
+                            <RaisedButton color="#00bbff">
+                                Get Started
+                            </RaisedButton>
+                        )}
+                    </div>
+                </div>
+
+                <AnimatePresence>
+                    {activeDropdown && (
+                        <NavbarMenu
+                            activeMenu={activeDropdown}
+                            sections={sections}
+                        />
+                    )}
+                </AnimatePresence>
+            </div>
         </div>
-
-        <AnimatePresence>
-          {activeDropdown && (
-            <NavbarMenu activeMenu={activeDropdown} sections={sections} />
-          )}
-        </AnimatePresence>
-      </div>
-    </div>
-  );
+    );
 }

--- a/registry/new-york/ui/slash-command-dropdown.tsx
+++ b/registry/new-york/ui/slash-command-dropdown.tsx
@@ -58,6 +58,7 @@ interface SlashCommandDropdownProps {
 // Default icon size for consistency
 const ICON_SIZE = 20;
 const CATEGORY_ICON_SIZE = 16;
+const MONOCHROME_ICON_CATEGORIES = new Set(["github", "linear"]);
 
 /**
  * Get a default icon for a tool based on its category
@@ -81,7 +82,11 @@ const getDefaultToolIcon = (
 	if (categoryIcon) return categoryIcon;
 
 	return (
-		<HugeiconsIcon icon={ToolsIcon} size={size} className="text-zinc-400" />
+		<HugeiconsIcon
+			icon={ToolsIcon}
+			size={size}
+			className="text-zinc-500 dark:text-zinc-400"
+		/>
 	);
 };
 
@@ -186,7 +191,7 @@ export const SlashCommandDropdown: React.FC<SlashCommandDropdownProps> = ({
 				// Base styles
 				"fixed z-[200] overflow-hidden rounded-2xl",
 				// Light mode support
-				"border border-zinc-200 bg-white/95 dark:border-zinc-800 dark:bg-zinc-900/95",
+				"border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900/95",
 				"backdrop-blur-xl shadow-2xl",
 				// Animation
 				"animate-in fade-in-0 slide-in-from-bottom-2 duration-200",
@@ -206,14 +211,14 @@ export const SlashCommandDropdown: React.FC<SlashCommandDropdownProps> = ({
 		>
 			{/* Header section - Only show when opened via button */}
 			{openedViaButton && (
-				<div className="flex items-center justify-between pl-5 pr-2 py-1">
+				<div className="flex items-center justify-between border-b border-zinc-200 dark:border-zinc-800 pl-5 pr-2 py-1">
 					<div className="text-xs font-semibold text-zinc-900 dark:text-zinc-100">
 						Browse Tools
 					</div>
 					<button
 						type="button"
 						onClick={onClose}
-						className="cursor-pointer rounded-full p-1.5 hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200 transition-colors"
+						className="cursor-pointer rounded-full p-1.5 hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-600 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200 transition-colors"
 						aria-label="Close"
 					>
 						<HugeiconsIcon icon={Cancel01Icon} size={16} />
@@ -223,7 +228,7 @@ export const SlashCommandDropdown: React.FC<SlashCommandDropdownProps> = ({
 
 			{/* Category Tabs */}
 			{computedCategories.length > 1 && (
-				<div>
+				<div className="border-b border-zinc-200 dark:border-zinc-800">
 					<div className="flex overflow-x-auto px-3 py-1 gap-1.5 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
 						{computedCategories.map((category) => (
 							<button
@@ -236,10 +241,16 @@ export const SlashCommandDropdown: React.FC<SlashCommandDropdownProps> = ({
 									// Selected state
 									selectedCategory === category
 										? "bg-zinc-100 text-zinc-900 dark:bg-zinc-700/50 dark:text-white"
-										: "text-zinc-500 hover:bg-zinc-50 hover:text-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800/50 dark:hover:text-zinc-300",
+										: "text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800/50 dark:hover:text-zinc-200",
 								)}
 							>
-								{getCategoryTabIcon(category)}
+									{category === "github" ? (
+										<span className="flex h-4 w-4 items-center justify-center rounded-sm bg-zinc-800 dark:bg-transparent">
+											{getCategoryTabIcon(category)}
+										</span>
+									) : (
+										getCategoryTabIcon(category)
+									)}
 								<span>
 									{category === "all" ? "All" : formatToolName(category)}
 								</span>
@@ -255,7 +266,7 @@ export const SlashCommandDropdown: React.FC<SlashCommandDropdownProps> = ({
 				className="max-h-[200px] overflow-y-auto py-1.5"
 			>
 				{filteredMatches.length === 0 ? (
-					<div className="px-4 py-8 text-center text-sm text-zinc-500 dark:text-zinc-400">
+					<div className="px-4 py-8 text-center text-sm text-zinc-600 dark:text-zinc-400">
 						No tools found
 					</div>
 				) : (
@@ -266,21 +277,27 @@ export const SlashCommandDropdown: React.FC<SlashCommandDropdownProps> = ({
 								type="button"
 								key={`${match.tool.category}-${match.tool.name}`}
 								data-index={index}
-								className={cn(
-									// Base styles - full width with consistent padding
-									"w-full text-left mx-0 px-3 py-0 cursor-pointer transition-all duration-150",
-									// Selected/hover states with light mode support
-									isSelected
-										? "bg-zinc-100 dark:bg-zinc-700/40"
-										: "hover:bg-zinc-50 dark:hover:bg-zinc-800/40",
-								)}
+									className={cn(
+										// Base styles - full width with consistent padding
+										"w-full text-left mx-0 px-3 py-0 cursor-pointer transition-all duration-150",
+										// Selected/hover states with light mode support
+										isSelected
+											? "bg-zinc-100 dark:bg-zinc-800"
+											: "hover:bg-zinc-100 dark:hover:bg-zinc-800",
+									)}
 								onClick={() => onSelect(match)}
 							>
 								<div className="flex items-center gap-3 py-2.5 px-1">
-									{/* Icon container - fixed size for consistency */}
-									<div className="flex-shrink-0 flex items-center justify-center w-8 h-8 rounded-lg bg-zinc-100 dark:bg-zinc-800">
-										{getDefaultToolIcon(match.tool, ICON_SIZE)}
-									</div>
+										{/* Icon container - fixed size for consistency */}
+										<div
+											className={cn(
+												"flex-shrink-0 flex h-8 w-8 items-center justify-center rounded-lg bg-zinc-100 dark:bg-zinc-800",
+												MONOCHROME_ICON_CATEGORIES.has(match.tool.category) &&
+													"[&_img]:brightness-0 dark:[&_img]:brightness-100",
+											)}
+										>
+											{getDefaultToolIcon(match.tool, ICON_SIZE)}
+										</div>
 
 									{/* Content - fills remaining space */}
 									<div className="min-w-0 flex-1">
@@ -289,13 +306,13 @@ export const SlashCommandDropdown: React.FC<SlashCommandDropdownProps> = ({
 												{formatToolName(match.tool.name)}
 											</span>
 											{selectedCategory === "all" && (
-												<span className="flex-shrink-0 rounded-md bg-zinc-100 dark:bg-zinc-800 px-2 py-0.5 text-xs text-zinc-500 dark:text-zinc-400">
+												<span className="flex-shrink-0 rounded-md bg-zinc-100 dark:bg-zinc-800 px-2 py-0.5 text-xs text-zinc-600 dark:text-zinc-400">
 													{formatToolName(match.tool.category)}
 												</span>
 											)}
 										</div>
 										{match.tool.description && (
-											<p className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5 truncate">
+											<p className="text-xs text-zinc-600 dark:text-zinc-400 mt-0.5 truncate">
 												{match.tool.description}
 											</p>
 										)}

--- a/registry/new-york/ui/slash-command-dropdown.tsx
+++ b/registry/new-york/ui/slash-command-dropdown.tsx
@@ -191,7 +191,7 @@ export const SlashCommandDropdown: React.FC<SlashCommandDropdownProps> = ({
 				// Base styles
 				"fixed z-[200] overflow-hidden rounded-2xl",
 				// Light mode support
-				"border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900/95",
+				"border border-zinc-200 dark:border-zinc-800 bg-background",
 				"backdrop-blur-xl shadow-2xl",
 				// Animation
 				"animate-in fade-in-0 slide-in-from-bottom-2 duration-200",
@@ -244,13 +244,13 @@ export const SlashCommandDropdown: React.FC<SlashCommandDropdownProps> = ({
 										: "text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800/50 dark:hover:text-zinc-200",
 								)}
 							>
-									{category === "github" ? (
-										<span className="flex h-4 w-4 items-center justify-center rounded-sm bg-zinc-800 dark:bg-transparent">
-											{getCategoryTabIcon(category)}
-										</span>
-									) : (
-										getCategoryTabIcon(category)
-									)}
+								{category === "github" ? (
+									<span className="flex h-4 w-4 items-center justify-center rounded-sm bg-zinc-800 dark:bg-transparent">
+										{getCategoryTabIcon(category)}
+									</span>
+								) : (
+									getCategoryTabIcon(category)
+								)}
 								<span>
 									{category === "all" ? "All" : formatToolName(category)}
 								</span>
@@ -277,27 +277,27 @@ export const SlashCommandDropdown: React.FC<SlashCommandDropdownProps> = ({
 								type="button"
 								key={`${match.tool.category}-${match.tool.name}`}
 								data-index={index}
-									className={cn(
-										// Base styles - full width with consistent padding
-										"w-full text-left mx-0 px-3 py-0 cursor-pointer transition-all duration-150",
-										// Selected/hover states with light mode support
-										isSelected
-											? "bg-zinc-100 dark:bg-zinc-800"
-											: "hover:bg-zinc-100 dark:hover:bg-zinc-800",
-									)}
+								className={cn(
+									// Base styles - full width with consistent padding
+									"w-full text-left mx-0 px-3 py-0 cursor-pointer transition-all duration-150",
+									// Selected/hover states with light mode support
+									isSelected
+										? "bg-zinc-100 dark:bg-zinc-800"
+										: "hover:bg-zinc-100 dark:hover:bg-zinc-800",
+								)}
 								onClick={() => onSelect(match)}
 							>
 								<div className="flex items-center gap-3 py-2.5 px-1">
-										{/* Icon container - fixed size for consistency */}
-										<div
-											className={cn(
-												"flex-shrink-0 flex h-8 w-8 items-center justify-center rounded-lg bg-zinc-100 dark:bg-zinc-800",
-												MONOCHROME_ICON_CATEGORIES.has(match.tool.category) &&
-													"[&_img]:brightness-0 dark:[&_img]:brightness-100",
-											)}
-										>
-											{getDefaultToolIcon(match.tool, ICON_SIZE)}
-										</div>
+									{/* Icon container - fixed size for consistency */}
+									<div
+										className={cn(
+											"flex-shrink-0 flex h-8 w-8 items-center justify-center rounded-lg bg-zinc-100 dark:bg-zinc-800",
+											MONOCHROME_ICON_CATEGORIES.has(match.tool.category) &&
+												"[&_img]:brightness-0 dark:[&_img]:brightness-100",
+										)}
+									>
+										{getDefaultToolIcon(match.tool, ICON_SIZE)}
+									</div>
 
 									{/* Content - fills remaining space */}
 									<div className="min-w-0 flex-1">


### PR DESCRIPTION
<img width="1902" height="1081" alt="image" src="https://github.com/user-attachments/assets/e5420c70-ab0a-40c8-a791-76146df04a44" />

--- 
<img width="1902" height="1081" alt="image" src="https://github.com/user-attachments/assets/a9bd020e-1065-45e9-906c-b07027a99c8f" />


- [x] Remove spacing from gallery page to fill width

- [x] Hovering on component should show tooltip to view this component page
----

- Redesigned the docs gallery to a full width preview layout with better card navigation.
- Fixed navbar-menu light mode.