### PR TITLE
fix(ci): unbreak Release workflow npm upgrade and create GitHub Releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
           cache: "pnpm"
 
       - name: Upgrade npm for Trusted Publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@latest --force
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -47,5 +47,6 @@ jobs:
           publish: pnpm run release
           commit: "chore: release"
           title: "chore: release"
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `--force` to `npm install -g npm@latest` so the Release workflow no longer crashes with `Cannot find module 'promise-retry'`
- Enable `createGithubReleases: true` on the Changesets action so each published version produces a matching GitHub Release (visible in the repo sidebar)

## Why
The previous Release run after merging #14 / #15 failed at the npm upgrade step. As a result, `0.3.3` is not on npm and the queued `cloudflare-opennext-fix` changeset was never consumed.

After this PR merges, the Release workflow will run again on `main`, open a "chore: release" PR bumping to `0.3.4`, and once that release PR is merged, OIDC publishes to npm (assuming Trusted Publishing is configured on npmjs.com).

## Test plan
- [ ] Workflow run for the merge into main reaches the `Create Release PR or Publish to npm` step without error
- [ ] A "chore: release" PR appears with `0.3.4` and the changelog entry
- [ ] After merging that PR, `@heygaia/ui@0.3.4` is published on npm with provenance
- [ ] A matching GitHub Release `v0.3.4` appears under "Releases" on the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)