### PR TITLE
fix(readme): correct broken repo links pointing to /ui instead of /gaia-ui

### DIFF
--- a/.changeset/readme-broken-repo-links.md
+++ b/.changeset/readme-broken-repo-links.md
@@ -1,0 +1,5 @@
+---
+"@heygaia/ui": patch
+---
+
+Fix broken repository links in the README — the badges, contributors graph, and star-history chart all pointed to `theexperiencecompany/ui` instead of the correct repo `theexperiencecompany/gaia-ui`.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Join our growing community of users and contributors:
 ## Contributing
 
 <a href="https://github.com/theexperiencecompany/gaia-ui/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=theexperiencecompany/gaia-ui" />
+  <img alt="Contributors" src="https://contrib.rocks/image?repo=theexperiencecompany/gaia-ui" />
 </a>
 
 We welcome contributions! Whether you're fixing bugs, improving documentation, or adding new components, we'd love your help.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # GAIA UI - Component Registry
 
-[![Status](https://img.shields.io/badge/Status-Beta-00ba6d)](https://ui.heygaia.io) [![Documentation](https://img.shields.io/badge/Docs-00bbff?style=flat&logo=gitbook&logoColor=white)](https://ui.heygaia.io) [![Latest Release](https://img.shields.io/github/v/release/theexperiencecompany/ui?color=00bbff)](https://github.com/theexperiencecompany/ui/releases)
+[![Status](https://img.shields.io/badge/Status-Beta-00ba6d)](https://ui.heygaia.io) [![Documentation](https://img.shields.io/badge/Docs-00bbff?style=flat&logo=gitbook&logoColor=white)](https://ui.heygaia.io) [![Latest Release](https://img.shields.io/github/v/release/theexperiencecompany/gaia-ui?color=00bbff)](https://github.com/theexperiencecompany/gaia-ui/releases)
 
-[![Contributors](https://img.shields.io/github/contributors/theexperiencecompany/ui)](https://github.com/theexperiencecompany/ui/graphs/contributors) [![Open Issues](https://img.shields.io/github/issues/theexperiencecompany/ui)](https://github.com/theexperiencecompany/ui/issues) [![License](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+[![Contributors](https://img.shields.io/github/contributors/theexperiencecompany/gaia-ui)](https://github.com/theexperiencecompany/gaia-ui/graphs/contributors) [![Open Issues](https://img.shields.io/github/issues/theexperiencecompany/gaia-ui)](https://github.com/theexperiencecompany/gaia-ui/issues) [![License](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
 [![Discord](https://discord-live-members-count-badge.vercel.app/api/discord-members?guildId=585464664650022914&color=5c6af3&label=Discord)](https://discord.heygaia.io) [![Twitter Follow](https://img.shields.io/twitter/follow/trygaia?style=social)](https://x.com/intent/user?screen_name=trygaia)
 
@@ -100,8 +100,8 @@ Join our growing community of users and contributors:
 
 ## Contributing
 
-<a href="https://github.com/theexperiencecompany/ui/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=theexperiencecompany/ui" />
+<a href="https://github.com/theexperiencecompany/gaia-ui/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=theexperiencecompany/gaia-ui" />
 </a>
 
 We welcome contributions! Whether you're fixing bugs, improving documentation, or adding new components, we'd love your help.
@@ -143,11 +143,11 @@ pnpm run type
 
 ## Star History
 
-<a href="https://www.star-history.com/#theexperiencecompany/ui&type=date&legend=top-left">
+<a href="https://www.star-history.com/#theexperiencecompany/gaia-ui&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=theexperiencecompany/ui&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=theexperiencecompany/ui&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=theexperiencecompany/ui&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=theexperiencecompany/gaia-ui&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=theexperiencecompany/gaia-ui&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=theexperiencecompany/gaia-ui&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
## Summary
- Replace 8 broken references to \`theexperiencecompany/ui\` with the correct repo path \`theexperiencecompany/gaia-ui\`
- Affects: release badge, contributors badge, contributors graph, contrib.rocks image, and the four star-history URLs

## Why
The repo lives at https://github.com/theexperiencecompany/gaia-ui but several README badges/links were pointing at \`/ui\` (without the \`gaia-\` prefix), so they were rendering empty data or 404ing depending on whether GitHub's redirect kicked in.

This PR also doubles as an end-to-end test of the new Changesets release flow: it includes a \`patch\` changeset, so once merged the Release workflow should open a "chore: release" PR bumping to \`0.3.4\`. Merging that release PR should publish to npm via OIDC.

## Test plan
- [ ] Render the README on GitHub after merge — all badges and the contributors/star-history charts populate correctly
- [ ] Release workflow runs cleanly on the merge to main (requires PR #16 to be merged first)
- [ ] A "chore: release" PR appears with version bump to \`0.3.4\` and changelog entry
- [ ] Merging the release PR publishes \`@heygaia/ui@0.3.4\` to npm
- [ ] A \`v0.3.4\` GitHub Release appears under the repo's Releases tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)