### PR TITLE
ci: bump Node to 24 and drop buggy npm self-upgrade

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,12 +30,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
-
-      - name: Upgrade npm for Trusted Publishing
-        run: npm install -g npm@latest --force
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Bump both workflows from Node 22 to Node 24 LTS, which already ships npm 11.x with Trusted Publishing support.
- Remove the `npm install -g npm@latest --force` step from the release workflow — it was crashing CI with `Cannot find module 'promise-retry'`.

## Why
Node 22.22.2 ships npm 10.x, so the release workflow self-upgraded npm to satisfy Trusted Publishing (npm ≥ 11.5.1). The `--force` flag tells npm to overwrite its own running files; recent npm releases relocated sub-deps, so mid-install npm tries to `require('promise-retry')` from a half-written new tree and crashes.

Node 24 ships a current npm out of the box, so the upgrade step is unnecessary.

## Test plan
- [ ] Release workflow succeeds on next push to `main`
- [ ] Changeset Check still runs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)