### PR TITLE
fix(package): add repository field for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,14 @@
     "release": "changeset publish"
   },
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/theexperiencecompany/gaia-ui.git"
+  },
+  "homepage": "https://ui.heygaia.io",
+  "bugs": {
+    "url": "https://github.com/theexperiencecompany/gaia-ui/issues"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- The release workflow was failing on `changeset publish` with `Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is ""`.
- npm provenance (enabled via OIDC trusted publishing) requires `package.json#repository.url` to match the GitHub repo URL inferred from the workflow's OIDC token.
- Added `repository`, `homepage` (`https://ui.heygaia.io`), and `bugs` fields.

## Test plan
- [ ] Merge and confirm the next Release workflow run successfully publishes `@heygaia/ui` to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)