### PR TITLE
feat(layout): add Rybbit analytics

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,74 +4,80 @@ import "@fontsource/inter/600.css";
 import "@fontsource/inter/700.css";
 import type { Metadata } from "next";
 import { Instrument_Serif } from "next/font/google";
+import Script from "next/script";
 import { ThemeProvider } from "next-themes";
 import "./globals.css";
 
 import { NavbarWrapper } from "@/components/core/navbar-wrapper";
 import { QueryProvider } from "@/components/providers/query-provider";
 import {
-	generateOrganizationSchema,
-	generateSEO,
-	generateWebsiteSchema,
+  generateOrganizationSchema,
+  generateSEO,
+  generateWebsiteSchema,
 } from "@/lib/seo";
 
 const instrumentSerif = Instrument_Serif({
-	weight: "400",
-	subsets: ["latin"],
-	variable: "--font-instrument-serif",
-	display: "swap",
+  weight: "400",
+  subsets: ["latin"],
+  variable: "--font-instrument-serif",
+  display: "swap",
 });
 
 export const metadata: Metadata = {
-	...generateSEO(),
-	metadataBase: new URL("https://ui.heygaia.io"),
+  ...generateSEO(),
+  metadataBase: new URL("https://ui.heygaia.io"),
 };
 
 export default function RootLayout({
-	children,
+  children,
 }: Readonly<{
-	children: React.ReactNode;
+  children: React.ReactNode;
 }>) {
-	const organizationSchema = generateOrganizationSchema();
-	const websiteSchema = generateWebsiteSchema();
+  const organizationSchema = generateOrganizationSchema();
+  const websiteSchema = generateWebsiteSchema();
 
-	return (
-		<html
-			lang="en"
-			suppressHydrationWarning
-			className={instrumentSerif.variable}
-		>
-			<head>
-				<link
-					rel="stylesheet"
-					type="text/css"
-					href="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/devicon.min.css"
-				/>
-				{/* JSON-LD Structured Data for better SEO */}
-				<script
-					type="application/ld+json"
-					dangerouslySetInnerHTML={{
-						__html: JSON.stringify(organizationSchema),
-					}}
-				/>
-				<script
-					type="application/ld+json"
-					dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteSchema) }}
-				/>
-			</head>
-			<body className="min-h-screen bg-background font-sans antialiased">
-				<ThemeProvider
-					attribute="class"
-					defaultTheme="system"
-					enableSystem
-					disableTransitionOnChange
-				>
-					<QueryProvider>
-						<NavbarWrapper />
-						{children}
-					</QueryProvider>
-				</ThemeProvider>
-			</body>
-		</html>
-	);
+  return (
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={instrumentSerif.variable}
+    >
+      <head>
+        <link
+          rel="stylesheet"
+          type="text/css"
+          href="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/devicon.min.css"
+        />
+        {/* JSON-LD Structured Data for better SEO */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(organizationSchema),
+          }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteSchema) }}
+        />
+      </head>
+      <body className="min-h-screen bg-background font-sans antialiased">
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <QueryProvider>
+            <NavbarWrapper />
+            {children}
+          </QueryProvider>
+        </ThemeProvider>
+        <Script
+          src="https://as.heygaia.io/api/script.js"
+          data-site-id="7fa95f48bd78"
+          strategy="afterInteractive"
+        />
+      </body>
+    </html>
+  );
 }


### PR DESCRIPTION
## Summary

- Adds the self-hosted Rybbit tracking script (https://as.heygaia.io) to `app/layout.tsx`
- Loaded via `next/script` with `strategy="afterInteractive"` so it stays off the critical path
- Site ID `7fa95f48bd78` (registered as `ui.heygaia.io` in the Rybbit dashboard)

## Test plan
- [ ] Deploy preview
- [ ] Open the site, verify `https://as.heygaia.io/api/script.js` request in DevTools
- [ ] Verify pageview shows up in Rybbit dashboard for ui.heygaia.io site